### PR TITLE
make update interval configurable for local connections

### DIFF
--- a/custom_components/mygekko/__init__.py
+++ b/custom_components/mygekko/__init__.py
@@ -6,7 +6,7 @@ https://github.com/stephanu/mygekko
 import logging
 
 from custom_components.mygekko.coordinator import MyGekkoDataUpdateCoordinator
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core_config import Config
 from homeassistant.core import HomeAssistant
@@ -35,7 +35,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     coordinator = MyGekkoDataUpdateCoordinator(hass, entry=entry)
 
-    await coordinator.async_config_entry_first_refresh()
+    if entry.state == ConfigEntryState.SETUP_IN_PROGRESS:
+        await coordinator.async_config_entry_first_refresh()
+    else:
+        await coordinator.async_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
@@ -81,5 +84,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/mygekko/const.py
+++ b/custom_components/mygekko/const.py
@@ -35,8 +35,12 @@ CONF_CONNECTION_LOCAL_LABEL = "Local"
 CONF_CONNECTION_DEMO_MODE = "demo_mode"
 CONF_CONNECTION_DEMO_MODE_LABEL = "Demo Mode"
 
+# Options configuration keys
+CONF_SCAN_INTERVAL = "scan_interval"
+
 # Defaults
 DEFAULT_NAME = DOMAIN
+DEFAULT_SCAN_INTERVAL = 30
 
 
 STARTUP_MESSAGE = f"""

--- a/custom_components/mygekko/coordinator.py
+++ b/custom_components/mygekko/coordinator.py
@@ -21,10 +21,9 @@ from .const import CONF_CONNECTION_LOCAL
 from .const import CONF_CONNECTION_MY_GEKKO_CLOUD
 from .const import CONF_CONNECTION_TYPE
 from .const import CONF_GEKKOID
+from .const import CONF_SCAN_INTERVAL
+from .const import DEFAULT_SCAN_INTERVAL
 from .const import DOMAIN
-
-
-SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -38,7 +37,9 @@ class MyGekkoDataUpdateCoordinator(DataUpdateCoordinator):
         entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
+        scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        update_interval = timedelta(seconds=scan_interval)
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=update_interval, config_entry=entry)
 
         client = None
 

--- a/custom_components/mygekko/translations/de.json
+++ b/custom_components/mygekko/translations/de.json
@@ -45,6 +45,23 @@
       "single_instance_allowed": "Es ist nur eine einzige Instanz zulässig."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "MyGekko Optionen",
+        "description": "Konfigurieren Sie integrationweite Einstellungen für MyGekko.",
+        "data": {
+          "scan_interval": "Aktualisierungsintervall (Sekunden)"
+        },
+        "data_description": {
+          "scan_interval": "Wie oft Ihr MyGekko-Gerät nach Aktualisierungen abgefragt werden soll. Niedrigere Werte bieten Echtzeit-Updates, erhöhen aber den Netzwerkverkehr. Bereich: 5-300 Sekunden. (Standard: 30 Sekunden)"
+        }
+      }
+    },
+    "abort": {
+      "not_local_connection": "Konfigurationsoptionen sind nur für lokale MyGekko-Verbindungen verfügbar."
+    }
+  },
   "entity": {
     "climate": {
       "mygekko_roomtemp": {

--- a/custom_components/mygekko/translations/en.json
+++ b/custom_components/mygekko/translations/en.json
@@ -45,6 +45,23 @@
       "single_instance_allowed": "Only a single instance is allowed."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "MyGekko Options",
+        "description": "Configure integration-wide settings for MyGekko.",
+        "data": {
+          "scan_interval": "Update interval (seconds)"
+        },
+        "data_description": {
+          "scan_interval": "How often to poll your MyGekko device for updates. Lower values provide more real-time updates but increase network traffic. Range: 5-300 seconds. (Default: 30 seconds)"
+        }
+      }
+    },
+    "abort": {
+      "not_local_connection": "Configuration options are only available for local MyGekko connections."
+    }
+  },
   "entity": {
     "climate": {
       "mygekko_roomtemp": {

--- a/custom_components/mygekko/translations/fr.json
+++ b/custom_components/mygekko/translations/fr.json
@@ -45,6 +45,23 @@
       "single_instance_allowed": "Une seule instance est autorisée."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options MyGekko",
+        "description": "Configurer les paramètres de l'intégration pour MyGekko.",
+        "data": {
+          "scan_interval": "Intervalle de mise à jour (secondes)"
+        },
+        "data_description": {
+          "scan_interval": "À quelle fréquence interroger votre appareil MyGekko pour les mises à jour. Des valeurs plus faibles fournissent des mises à jour en temps réel mais augmentent le trafic réseau. Plage: 5-300 secondes. (Par défaut: 30 secondes)"
+        }
+      }
+    },
+    "abort": {
+      "not_local_connection": "Les options de configuration ne sont disponibles que pour les connexions MyGekko locales."
+    }
+  },
   "entity": {
     "climate": {
       "mygekko_roomtemp": {

--- a/custom_components/mygekko/translations/it.json
+++ b/custom_components/mygekko/translations/it.json
@@ -45,6 +45,23 @@
       "single_instance_allowed": "È consentita una sola istanza."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opzioni MyGekko",
+        "description": "Configurare le impostazioni per l'integrazione MyGekko.",
+        "data": {
+          "scan_interval": "Intervallo di aggiornamento (secondi)"
+        },
+        "data_description": {
+          "scan_interval": "Con quale frequenza interrogare il dispositivo MyGekko per gli aggiornamenti. Valori più bassi forniscono aggiornamenti in tempo reale ma aumentano il traffico di rete. Intervallo: 5-300 secondi. (Predefinito: 30 secondi)"
+        }
+      }
+    },
+    "abort": {
+      "not_local_connection": "Le opzioni di configurazione sono disponibili solo per le connessioni MyGekko locali."
+    }
+  },
   "entity": {
     "climate": {
       "mygekko_roomtemp": {

--- a/custom_components/mygekko/translations/nb.json
+++ b/custom_components/mygekko/translations/nb.json
@@ -45,6 +45,23 @@
       "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "MyGekko Alternativer",
+        "description": "Konfigurer integrasjonsinnstillinger for MyGekko.",
+        "data": {
+          "scan_interval": "Oppdateringsintervall (sekunder)"
+        },
+        "data_description": {
+          "scan_interval": "Hvor ofte MyGekko-enheten skal spørres etter oppdateringer. Lavere verdier gir sanntidsoppdateringer, men øker nettverkstrafikken. Område: 5-300 sekunder. (Standard: 30 sekunder)"
+        }
+      }
+    },
+    "abort": {
+      "not_local_connection": "Konfigurasjonsalternativer er bare tilgjengelige for lokale MyGekko-tilkoblinger."
+    }
+  },
   "entity": {
     "climate": {
       "mygekko_roomtemp": {


### PR DESCRIPTION
First of all, big thank you for maintaining this custom myGekko integration. It works like a charm and it is much appreciated!

I noticed that especially for covers, the status in home assistant can lag behind quit a bit when opening or closing them. Decreasing the update interval makes this work much more seamlessly and the correct status is reflected way faster in the UI.

However, to not overload the public myGekko Cloud API, I opted to make this only configurable when using the local connection. I tested it with 5 seconds on my myGekko and it does not seem to overload it.

This is my first time playing around with a home assistant integration. Let me know if you have any feedback, happy to adjust accordingly.