### PR TITLE
Request coordinator refresh after entity commands

### DIFF
--- a/custom_components/mygekko/button.py
+++ b/custom_components/mygekko/button.py
@@ -39,6 +39,7 @@ class MyGekkoLightGroupOnButton(MyGekkoEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         await self._light.set_state(LightState.ON)
+        await self.coordinator.async_request_refresh()
 
 
 class MyGekkoLightGroupOffButton(MyGekkoEntity, ButtonEntity):
@@ -54,3 +55,4 @@ class MyGekkoLightGroupOffButton(MyGekkoEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         await self._light.set_state(LightState.OFF)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/climate.py
+++ b/custom_components/mygekko/climate.py
@@ -72,6 +72,7 @@ class MyGekkoRoomTempClimate(MyGekkoEntity, ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         await self._room_temp.set_target_temperature(float(kwargs[ATTR_TEMPERATURE]))
+        await self.coordinator.async_request_refresh()
 
     @property
     def preset_mode(self) -> str | None:
@@ -90,6 +91,7 @@ class MyGekkoRoomTempClimate(MyGekkoEntity, ClimateEntity):
         """Set new preset mode."""
 
         await self._room_temp.set_working_mode(preset_mode)
+        await self.coordinator.async_request_refresh()
 
     @property
     def current_humidity(self) -> int | None:

--- a/custom_components/mygekko/cover.py
+++ b/custom_components/mygekko/cover.py
@@ -114,33 +114,41 @@ class MyGekkoCover(MyGekkoEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any):
         """Open the cover."""
         await self._blind.set_state(BlindState.HOLD_UP)
+        await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any):
         """Close cover."""
         await self._blind.set_state(BlindState.HOLD_DOWN)
+        await self.coordinator.async_request_refresh()
 
     async def async_stop_cover(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         # myGekko blinds are closed on 100 and open on 0
         await self._blind.set_position(100.0 - float(kwargs[ATTR_POSITION]))
+        await self.coordinator.async_request_refresh()
 
     async def async_open_cover_tilt(self, **kwargs: Any):
         """Open the cover."""
         await self._blind.set_tilt_position(0.0)
+        await self.coordinator.async_request_refresh()
 
     async def async_close_cover_tilt(self, **kwargs: Any):
         """Close cover."""
         await self._blind.set_tilt_position(100.0)
+        await self.coordinator.async_request_refresh()
 
     async def async_stop_cover_tilt(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        await self.coordinator.async_request_refresh()
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         # myGekko blinds are closed on 100 and open on 0
         await self._blind.set_tilt_position(100.0 - float(kwargs[ATTR_TILT_POSITION]))
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/light.py
+++ b/custom_components/mygekko/light.py
@@ -70,6 +70,7 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
         """Turn off the light."""
         _LOGGER.debug("Switch off light %s", self._light.name)
         await self._light.set_state(LightState.OFF)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the light."""
@@ -80,6 +81,7 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
             await self._light.set_brightness(round(kwargs[ATTR_BRIGHTNESS] / 255 * 100))
         else:
             await self._light.set_state(LightState.ON)
+        await self.coordinator.async_request_refresh()
 
     @property
     def brightness(self) -> int | None:

--- a/custom_components/mygekko/scene.py
+++ b/custom_components/mygekko/scene.py
@@ -37,3 +37,4 @@ class MyGekkoScene(MyGekkoControllerEntity, Scene):
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         await self._action.set_state(ActionState.ON)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/select.py
+++ b/custom_components/mygekko/select.py
@@ -57,6 +57,7 @@ class MyGekkoVentBypassSelect(MyGekkoEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_bypass_state(option)
+        await self.coordinator.async_request_refresh()
 
 
 class MyGekkoVentWorkingModeSelect(MyGekkoEntity, SelectEntity):
@@ -89,6 +90,7 @@ class MyGekkoVentWorkingModeSelect(MyGekkoEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_mode(option)
+        await self.coordinator.async_request_refresh()
 
 
 class MyGekkoVentWorkingLevelSelect(MyGekkoEntity, SelectEntity):
@@ -122,3 +124,4 @@ class MyGekkoVentWorkingLevelSelect(MyGekkoEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_level(option)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/switch.py
+++ b/custom_components/mygekko/switch.py
@@ -42,7 +42,9 @@ class MyGekkoSwitch(MyGekkoEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
         await self._load.set_state(LoadState.OFF)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
         await self._load.set_state(LoadState.ON_PERMANENT)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/water_heater.py
+++ b/custom_components/mygekko/water_heater.py
@@ -60,11 +60,13 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
         """Turn off the water heater."""
         _LOGGER.debug("Switch off water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.OFF)
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the water heater."""
         _LOGGER.debug("Switch on water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.ON)
+        await self.coordinator.async_request_refresh()
 
     @property
     def target_temperature(self) -> float | None:
@@ -82,6 +84,7 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
         await self._hotwater_system.set_target_temperature(
             float(kwargs[ATTR_TEMPERATURE])
         )
+        await self.coordinator.async_request_refresh()
 
     @property
     def current_temperature(self) -> float | None:


### PR DESCRIPTION
I noticed that when triggering some action in HA, the user who did it is not recorded in the logbook. It just says something like "Cover Opened" without _who_ it did.
When requesting a immediate refresh of the entity state that seems to be recorded correctly.

Tested with covers over a local connection.
Would be good if someone else who uses this integration more extensively can also test it before merging.