### PR TITLE
Changed iot_class to local_polling

### DIFF
--- a/custom_components/mygekko/manifest.json
+++ b/custom_components/mygekko/manifest.json
@@ -7,7 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/stephanu/mygekko",
-  "iot_class": "cloud_polling",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/stephanu/mygekko/issues",
   "loggers": [
     "PyMyGekko"


### PR DESCRIPTION
The manifest declared `iot_class: cloud_polling`, but the integration supports both the local Query API and the myGEKKO Plus cloud API — with the local connection being the primary option (it works without a Plus subscription). `local_polling` therefore describes the integration better.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)