### PR TITLE
Fix config entry migration on current Home Assistant versions

### DIFF
--- a/custom_components/mygekko/__init__.py
+++ b/custom_components/mygekko/__init__.py
@@ -53,16 +53,14 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         new = {**config_entry.data}
         new[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
 
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version=2)
 
     if config_entry.version == 2:
         new = {**config_entry.data}
         new[CONF_API_KEY] = new["apikey"]
         new.pop("apikey")
 
-        config_entry.version = 3
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version=3)
 
     _LOGGER.debug("Migration to version %s successful", config_entry.version)
 


### PR DESCRIPTION
## Summary

`async_migrate_entry` sets `config_entry.version` directly. On current Home Assistant versions this raises:

```
AttributeError: version cannot be changed directly, use async_update_entry instead
```

`version` (and `minor_version`) are part of `UPDATE_ENTRY_CONFIG_ENTRY_ATTRS` and can no longer be assigned directly. This fixes it by passing the new version to `async_update_entry()`, which is the pattern recommended in the [HA developer docs](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/):

```python
hass.config_entries.async_update_entry(config_entry, data=new, version=2)
```

This is a latent bug: `async_migrate_entry` only runs for entries older than the current version (3), so anyone whose entries are already v3 never hits it. It only surfaces when upgrading an old v1/v2 entry on a recent HA release.

## Testing

- `ruff check .` passes
- Reproduced the `AttributeError` on `homeassistant==2026.2.3` by setting `entry.version = 2` on a real `ConfigEntry`
- Confirmed the recommended `async_update_entry(..., version=...)` pattern in the official HA docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)