### PR TITLE
Use the gekko name as entry title and allow reconfiguring an entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ custom_components/mygekko/switch.py
 
 The integration supports access via the MyGekko Query Api (you need a MyGekko Plus subscription) or by connecting to your MyGekko locally.
 
+To change the settings of an existing entry — IP address, credentials or even the connection type itself — open "Settings" -> "Devices & services" -> "MyGekko" and pick "Reconfigure" from the entry's menu.
+
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)

--- a/custom_components/mygekko/__init__.py
+++ b/custom_components/mygekko/__init__.py
@@ -41,7 +41,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
     return True
 
 
@@ -77,9 +76,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -108,7 +108,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_selection",
-            data_schema=self._with_current_values(CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(CONNECTION_SCHEMA, user_input),
             errors=self._errors,
             last_step=False,
         )
@@ -143,7 +143,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_mygekko_cloud",
-            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA, user_input),
             errors=self._errors,
         )
 
@@ -177,7 +177,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_local",
-            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA, user_input),
             errors=self._errors,
         )
 
@@ -186,13 +186,18 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Return whether an existing entry is being reconfigured."""
         return self.source == config_entries.SOURCE_RECONFIGURE
 
-    def _with_current_values(self, schema):
-        """Prefill a form with the data of the entry that is being reconfigured."""
+    def _with_current_values(self, schema, user_input=None):
+        """Prefill a form with the data of the entry that is being reconfigured.
+
+        What the user just submitted takes precedence over what is stored, so a
+        form redisplayed after a validation error keeps their input instead of
+        resetting it to the values they are trying to replace.
+        """
         if not self._is_reconfigure:
             return schema
 
         return self.add_suggested_values_to_schema(
-            schema, self._get_reconfigure_entry().data
+            schema, {**self._get_reconfigure_entry().data, **(user_input or {})}
         )
 
     def _async_update_entry(self, data):
@@ -238,8 +243,10 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             globals_network = client.get_globals_network()
             if globals_network:
                 return globals_network.get("gekkoname")
-        except ClientConnectorError:
-            _LOGGER.exception("ClientConnectorError")
-        except MyGekkoError:
-            _LOGGER.exception("MyGekkoError")
+        except Exception:  # noqa: BLE001
+            # The name is only used as the entry title and has a fallback, so no
+            # failure here may abort a flow whose credentials already validated.
+            # get_globals_network() indexes the payload without guarding, which
+            # raises KeyError on an unexpected response.
+            _LOGGER.debug("Could not determine the gekko name", exc_info=True)
         return None

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -78,6 +78,13 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_connection_selection(user_input)
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle a flow initialized by reconfiguring an existing entry."""
+        self._errors = {}
+        _LOGGER.debug("Config flow async_step_reconfigure %s", user_input)
+
+        return await self.async_step_connection_selection(user_input)
+
     async def async_step_connection_selection(self, user_input):
         """Show the configuration form to edit location data."""
         _LOGGER.debug("Config flow async_step_connection_selection %s", user_input)
@@ -92,13 +99,16 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_connection_local(user_input)
 
             if connection_type == CONF_CONNECTION_DEMO_MODE:
+                if self._is_reconfigure:
+                    return self._async_update_entry(user_input)
+
                 return self.async_create_entry(
                     title=CONF_CONNECTION_DEMO_MODE_LABEL, data=user_input
                 )
 
         return self.async_show_form(
             step_id="connection_selection",
-            data_schema=CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(CONNECTION_SCHEMA),
             errors=self._errors,
             last_step=False,
         )
@@ -120,6 +130,9 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
+                    if self._is_reconfigure:
+                        return self._async_update_entry(user_input)
+
                     gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
                         title=gekko_name or user_input[CONF_GEKKOID],
@@ -130,7 +143,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_mygekko_cloud",
-            data_schema=CLOUD_CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA),
             errors=self._errors,
         )
 
@@ -151,6 +164,9 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_LOCAL
+                    if self._is_reconfigure:
+                        return self._async_update_entry(user_input)
+
                     gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
                         title=gekko_name or user_input[CONF_IP_ADDRESS],
@@ -161,8 +177,31 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_local",
-            data_schema=LOCAL_CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA),
             errors=self._errors,
+        )
+
+    @property
+    def _is_reconfigure(self):
+        """Return whether an existing entry is being reconfigured."""
+        return self.source == config_entries.SOURCE_RECONFIGURE
+
+    def _with_current_values(self, schema):
+        """Prefill a form with the data of the entry that is being reconfigured."""
+        if not self._is_reconfigure:
+            return schema
+
+        return self.add_suggested_values_to_schema(
+            schema, self._get_reconfigure_entry().data
+        )
+
+    def _async_update_entry(self, data):
+        """Update the entry that is being reconfigured and finish the flow."""
+        # Replace the data instead of merging it, so switching the connection
+        # type does not leave the credentials of the previous one behind. The
+        # title is left untouched, the user may have renamed the entry.
+        return self.async_update_reload_and_abort(
+            self._get_reconfigure_entry(), data=data
         )
 
     async def _test_credentials_cloud_mygekko(self, username, apikey, gekkoid):

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -113,15 +113,17 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 and CONF_API_KEY in user_input
                 and CONF_GEKKOID in user_input
             ):
-                valid = await self._test_credentials_cloud_mygekko(
+                client = await self._test_credentials_cloud_mygekko(
                     user_input[CONF_USERNAME],
                     user_input[CONF_API_KEY],
                     user_input[CONF_GEKKOID],
                 )
-                if valid:
+                if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
+                    gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
-                        title=user_input[CONF_USERNAME], data=user_input
+                        title=gekko_name or user_input[CONF_GEKKOID],
+                        data=user_input,
                     )
                 else:
                     self._errors["base"] = "auth_cloud"
@@ -142,15 +144,17 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 and CONF_USERNAME in user_input
                 and CONF_PASSWORD in user_input
             ):
-                valid = await self._test_credentials_local_mygekko(
+                client = await self._test_credentials_local_mygekko(
                     user_input[CONF_IP_ADDRESS],
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
                 )
-                if valid:
+                if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_LOCAL
+                    gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
-                        title=user_input[CONF_USERNAME], data=user_input
+                        title=gekko_name or user_input[CONF_IP_ADDRESS],
+                        data=user_input,
                     )
                 else:
                     self._errors["base"] = "auth_local"
@@ -162,28 +166,41 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _test_credentials_cloud_mygekko(self, username, apikey, gekkoid):
-        """Return true if credentials is valid."""
+        """Return the client if the credentials are valid, None otherwise."""
         try:
             session = async_create_clientsession(self.hass)
             client = MyGekkoQueryApiClient(username, apikey, gekkoid, session)
             await client.try_connect()
-            return True
+            return client
         except ClientConnectorError:
             _LOGGER.exception("ClientConnectorError")
         except MyGekkoError:
             _LOGGER.exception("MyGekkoError")
-        return False
+        return None
 
     async def _test_credentials_local_mygekko(self, ip_address, username, password):
-        """Return true if credentials is valid."""
+        """Return the client if the credentials are valid, None otherwise."""
         try:
             session = async_create_clientsession(self.hass, verify_ssl=False)
             client = MyGekkoLocalApiClient(username, password, session, ip_address)
             await client.try_connect()
-            return True
+            return client
         except ClientConnectorError:
             _LOGGER.exception("ClientConnectorError")
         except MyGekkoError:
             _LOGGER.exception("MyGekkoError")
 
-        return False
+        return None
+
+    async def _read_gekko_name(self, client):
+        """Read the gekko friendly name, None if it cannot be determined."""
+        try:
+            await client.read_data()
+            globals_network = client.get_globals_network()
+            if globals_network:
+                return globals_network.get("gekkoname")
+        except ClientConnectorError:
+            _LOGGER.exception("ClientConnectorError")
+        except MyGekkoError:
+            _LOGGER.exception("MyGekkoError")
+        return None

--- a/custom_components/mygekko/translations/de.json
+++ b/custom_components/mygekko/translations/de.json
@@ -42,7 +42,8 @@
       "auth_local": "Benutzername, Password oder IP Adresse sind falsch. Details findest du in den Protokollen."
     },
     "abort": {
-      "single_instance_allowed": "Es ist nur eine einzige Instanz zulässig."
+      "single_instance_allowed": "Es ist nur eine einzige Instanz zulässig.",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/en.json
+++ b/custom_components/mygekko/translations/en.json
@@ -42,7 +42,8 @@
       "auth_local": "Username/Password/IP address is wrong. Please see the logs for details."
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
+      "reconfigure_successful": "Reconfiguration was successful"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/fr.json
+++ b/custom_components/mygekko/translations/fr.json
@@ -42,7 +42,8 @@
       "auth_local": "Nom d'utilisateur ou le mot de passe ou l'adresse IP erroné. Veuillez consulter les journaux pour plus de détails."
     },
     "abort": {
-      "single_instance_allowed": "Une seule instance est autorisée."
+      "single_instance_allowed": "Une seule instance est autorisée.",
+      "reconfigure_successful": "La reconfiguration a réussi"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/it.json
+++ b/custom_components/mygekko/translations/it.json
@@ -42,7 +42,8 @@
       "auth_local": "Nome utente/Password/Indirizzo IP errati. Per i dettagli, consultare i registri."
     },
     "abort": {
-      "single_instance_allowed": "È consentita una sola istanza."
+      "single_instance_allowed": "È consentita una sola istanza.",
+      "reconfigure_successful": "La riconfigurazione è avvenuta con successo"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/nb.json
+++ b/custom_components/mygekko/translations/nb.json
@@ -42,7 +42,8 @@
       "auth_local": "Brukernavn/Wachtwoord/IP-adres er feil. Raadpleeg de logboeken voor meer informatie."
     },
     "abort": {
-      "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang."
+      "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang.",
+      "reconfigure_successful": "Rekonfigurering var vellykket"
     }
   },
   "entity": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,6 @@
 """Test MyGekko setup process."""
 import pytest
 from custom_components.mygekko import (
-    async_reload_entry,
-)
-from custom_components.mygekko import (
     async_setup_entry,
 )
 from custom_components.mygekko import (
@@ -29,7 +26,7 @@ from .const import MOCK_CONFIG
 
 
 @pytest.mark.asyncio
-async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
+async def test_setup_and_unload_entry(hass, bypass_get_data):
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
@@ -38,13 +35,6 @@ async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     # them to be. Because we have patched the MyGekkoDataUpdateCoordinator.async_get_data
     # call, no code from custom_components/mygekko/api.py actually runs.
     assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], MyGekkoDataUpdateCoordinator
-    )
-
-    # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
     assert isinstance(
         hass.data[DOMAIN][config_entry.entry_id], MyGekkoDataUpdateCoordinator


### PR DESCRIPTION
Supersedes #381 — that PR's commit is included here unchanged, the two touch the same lines and are easier to review together. Based directly on `main`, no dependency on any other open PR.

## 1. Use the gekko name as the config entry title (was #381)

The config entry title currently shows the API **username**, which is not a useful way to tell entries apart — especially when a setup has one entry per floor/controller. This changes the title to the **gekko friendly name** (as configured in the myGEKKO controller itself, e.g. `1 Stock`), read via `get_globals_network()["gekkoname"]`. If it cannot be determined it falls back to the gekko id for cloud connections and the IP address for local ones. Existing entries are left untouched.

## 2. Allow reconfiguring an existing entry

There is no way to change the settings of a configured entry — no options flow, no reconfigure flow. When the myGEKKO gets a new IP address, or the local API password is rotated, the only option is to delete the entry and set it up again. That drops every entity together with its history, area assignment, and any automation or dashboard referencing it.

The config flow now implements [`async_step_reconfigure`](https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#reconfigure), which makes "Reconfigure" appear in the entry menu. It re-enters the existing `connection_selection` step, so the whole connection can be changed — including switching between the Query API, a local connection and demo mode — and each form is prefilled with what is currently configured via `add_suggested_values_to_schema`. Credentials are validated exactly as during initial setup; on failure the entry is left untouched and the error is shown on the form.

Three decisions worth calling out:

- **The entry data is replaced, not merged.** The docs' example uses `data_updates`, but that only overrides the keys it is given. Switching from a local connection to the Query API would leave `ip_address` and `password` behind in the entry, so `data=` is used instead.
- **The title is left untouched when reconfiguring.** The user may well have renamed the entry (I have one per floor here), so a reconfiguration must not overwrite it. For the same reason the gekko name is not read back on that path, which also saves the extra `read_data()` round trip that part 1 introduces.
- **No `async_set_unique_id()` / `_abort_if_unique_id_mismatch()`.** The config entries carry no unique id in this integration, and #383 scopes entity ids to the config entry id rather than to a device identity, so there is nothing to guard a mismatch against.

## Also included

`entry.add_update_listener(async_reload_entry)` is removed. It was registered in `async_setup_entry` without ever being unsubscribed, and `async_setup_entry` runs again on every reload — so the listeners accumulated and the next entry update would have reloaded the entry once per listener. Home Assistant reloads the entry itself as part of `async_update_reload_and_abort`, so nothing has to take its place. `async_reload_entry` had no other callers.

## Testing

`ruff check .` passes. No tests are included: the suite on `main` cannot run at all (it still targets a `user` step and an options flow that no longer exist, and patches `MyGekkoApiClient`, gone since the move to PyMyGekko), and repairing it is #384's job — keeping this PR independent of that one means shipping it without tests.

They do exist, though. I verified this branch against #384's repaired fixtures locally, plus three new tests covering the reconfigure flow: changing the credentials of an existing entry (prefilled form, data updated, title and entry count unchanged), switching the connection type (previous credentials gone rather than merged), and invalid credentials leaving the entry untouched. All three pass. I'll open a follow-up with them once #384 is in, or fold them into #384 if you prefer.

Verified on my own installation: reconfiguring an existing entry, switching the connection type, and a failed validation all behave as described.

## Since the first draft

Two fixes went in after reviewing this against the developer docs:

- `_read_gekko_name()` caught only `ClientConnectorError` and `MyGekkoError`. `get_globals_network()` indexes the payload without guarding and raises `KeyError` on an unexpected response, and `read_data` can raise `TimeoutError` — either escaped *after* the credentials had already validated and aborted the flow with "Unknown error occurred", leaving the integration impossible to set up. The name is optional and has a fallback, so it now swallows everything and logs at debug level.
- A form redisplayed after a validation error was prefilled from the stored entry data, discarding what the user had just typed. Submitted values now win.

**Note for whoever merges this and #384:** together they need a small test adaptation that neither branch can carry alone — this PR titles entries after the gekko name, so `bypass_try_connect` has to stub `read_data`/`get_globals_network` and the title assertions have to follow. I have the diff ready and will send it as a follow-up to whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

