### PR TITLE
Optimistic state updates for immediate UI feedback

### DIFF
--- a/custom_components/mygekko/climate.py
+++ b/custom_components/mygekko/climate.py
@@ -67,30 +67,36 @@ class MyGekkoRoomTempClimate(MyGekkoEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        return self._room_temp.target_temperature
+        return self._get_optimistic(
+            "target_temperature", self._room_temp.target_temperature
+        )
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await self._room_temp.set_target_temperature(float(kwargs[ATTR_TEMPERATURE]))
+        target_temperature = float(kwargs[ATTR_TEMPERATURE])
+        await self._room_temp.set_target_temperature(target_temperature)
+        self._set_optimistic(
+            "target_temperature",
+            target_temperature,
+            self._room_temp.target_temperature,
+        )
         await self.coordinator.async_request_refresh()
 
     @property
     def preset_mode(self) -> str | None:
         """Return preset mode."""
-        _LOGGER.debug(
-            "The mode of %s is %s", self._room_temp.name, self._room_temp.working_mode
+        working_mode = self._get_optimistic(
+            "working_mode", self._room_temp.working_mode
         )
+        _LOGGER.debug("The mode of %s is %s", self._room_temp.name, working_mode)
 
-        return (
-            str(self._room_temp.working_mode)
-            if self._room_temp.working_mode is not None
-            else None
-        )
+        return str(working_mode) if working_mode is not None else None
 
     async def async_set_preset_mode(self, preset_mode) -> None:
         """Set new preset mode."""
 
         await self._room_temp.set_working_mode(preset_mode)
+        self._set_optimistic("working_mode", preset_mode, self._room_temp.working_mode)
         await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/mygekko/cover.py
+++ b/custom_components/mygekko/cover.py
@@ -98,38 +98,45 @@ class MyGekkoCover(MyGekkoEntity, CoverEntity):
     @property
     def is_closing(self) -> bool:
         """Check whether the cover is closing."""
-        return (
-            self._blind.state == BlindState.DOWN
-            or self._blind.state == BlindState.HOLD_DOWN
-        )
+        state = self._get_optimistic("state", self._blind.state)
+        return state == BlindState.DOWN or state == BlindState.HOLD_DOWN
 
     @property
     def is_opening(self) -> bool:
         """Check whether the cover is opening."""
-        return (
-            self._blind.state == BlindState.UP
-            or self._blind.state == BlindState.HOLD_UP
-        )
+        state = self._get_optimistic("state", self._blind.state)
+        return state == BlindState.UP or state == BlindState.HOLD_UP
 
     async def async_open_cover(self, **kwargs: Any):
         """Open the cover."""
         await self._blind.set_state(BlindState.HOLD_UP)
+        self._set_optimistic("state", BlindState.HOLD_UP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any):
         """Close cover."""
         await self._blind.set_state(BlindState.HOLD_DOWN)
+        self._set_optimistic("state", BlindState.HOLD_DOWN, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_stop_cover(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        self._set_optimistic("state", BlindState.STOP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         # myGekko blinds are closed on 100 and open on 0
-        await self._blind.set_position(100.0 - float(kwargs[ATTR_POSITION]))
+        position = 100.0 - float(kwargs[ATTR_POSITION])
+        await self._blind.set_position(position)
+        if self._blind.position is not None and position != self._blind.position:
+            direction = (
+                BlindState.DOWN
+                if position > self._blind.position
+                else BlindState.UP
+            )
+            self._set_optimistic("state", direction, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_open_cover_tilt(self, **kwargs: Any):
@@ -145,6 +152,7 @@ class MyGekkoCover(MyGekkoEntity, CoverEntity):
     async def async_stop_cover_tilt(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        self._set_optimistic("state", BlindState.STOP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:

--- a/custom_components/mygekko/entity.py
+++ b/custom_components/mygekko/entity.py
@@ -1,5 +1,7 @@
 """MyGekkoEntity class."""
 import logging
+import time
+from typing import Any
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -10,6 +12,11 @@ from .const import MANUFACTURER
 from .const import NAME
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# How long (in seconds) an optimistic value is shown before falling back to
+# the polled value. Long enough to bridge a stale poll right after a command,
+# short enough to recover from commands the myGekko never applied.
+OPTIMISTIC_VALUE_TIMEOUT = 60.0
 
 
 class MyGekkoEntity(CoordinatorEntity):
@@ -23,6 +30,8 @@ class MyGekkoEntity(CoordinatorEntity):
         """Initialize a MyGekko entity."""
         super().__init__(coordinator)
 
+        self._optimistic_values: dict[str, tuple[Any, Any, float]] = {}
+
         device_id = f"{entity_prefix}{entity.entity_id}"
         device_name = entity.name
 
@@ -35,6 +44,31 @@ class MyGekkoEntity(CoordinatorEntity):
         )
 
         _LOGGER.debug("Added MyGekko entity id='%s'", self.unique_id)
+
+    def _set_optimistic(self, key: str, optimistic_value, polled_value) -> None:
+        """Show a value immediately instead of waiting for the next poll.
+
+        The optimistic value is returned by _get_optimistic until the polled
+        value changes (the myGekko has processed the command) or the timeout
+        expires (the command got lost), so a stale poll right after a command
+        does not flip the state back.
+        """
+        self._optimistic_values[key] = (
+            optimistic_value,
+            polled_value,
+            time.monotonic() + OPTIMISTIC_VALUE_TIMEOUT,
+        )
+        self.async_write_ha_state()
+
+    def _get_optimistic(self, key: str, polled_value):
+        """Return the optimistic value for key while it is valid."""
+        if key not in self._optimistic_values:
+            return polled_value
+        optimistic_value, initial_value, valid_until = self._optimistic_values[key]
+        if polled_value != initial_value or time.monotonic() >= valid_until:
+            del self._optimistic_values[key]
+            return polled_value
+        return optimistic_value
 
 
 class MyGekkoControllerEntity(CoordinatorEntity):

--- a/custom_components/mygekko/light.py
+++ b/custom_components/mygekko/light.py
@@ -61,15 +61,15 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
     @property
     def is_on(self) -> bool | None:
         """Check whether the light is on."""
-        _LOGGER.debug(
-            "The light state of %s is %d", self._light.name, self._light.state
-        )
-        return self._light.state == LightState.ON
+        state = self._get_optimistic("state", self._light.state)
+        _LOGGER.debug("The light state of %s is %d", self._light.name, state)
+        return state == LightState.ON
 
     async def async_turn_off(self, **kwargs):
         """Turn off the light."""
         _LOGGER.debug("Switch off light %s", self._light.name)
         await self._light.set_state(LightState.OFF)
+        self._set_optimistic("state", LightState.OFF, self._light.state)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
@@ -77,22 +77,25 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
         _LOGGER.debug("Switch on light %s", self._light.name)
         if ATTR_RGB_COLOR in kwargs and kwargs[ATTR_RGB_COLOR]:
             await self._light.set_rgb_color(kwargs[ATTR_RGB_COLOR])
+            self._set_optimistic(
+                "rgb_color", kwargs[ATTR_RGB_COLOR], self._light.rgb_color
+            )
         elif ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS]:
-            await self._light.set_brightness(round(kwargs[ATTR_BRIGHTNESS] / 255 * 100))
+            brightness = round(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+            await self._light.set_brightness(brightness)
+            self._set_optimistic("brightness", brightness, self._light.brightness)
         else:
             await self._light.set_state(LightState.ON)
+        self._set_optimistic("state", LightState.ON, self._light.state)
         await self.coordinator.async_request_refresh()
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return (
-            round(255 * self._light.brightness / 100)
-            if self._light.brightness is not None
-            else None
-        )
+        brightness = self._get_optimistic("brightness", self._light.brightness)
+        return round(255 * brightness / 100) if brightness is not None else None
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value [int, int, int]."""
-        return self._light.rgb_color
+        return self._get_optimistic("rgb_color", self._light.rgb_color)

--- a/custom_components/mygekko/light.py
+++ b/custom_components/mygekko/light.py
@@ -86,7 +86,10 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
             self._set_optimistic("brightness", brightness, self._light.brightness)
         else:
             await self._light.set_state(LightState.ON)
-        self._set_optimistic("state", LightState.ON, self._light.state)
+            # Only claimed for a real state command: writing a color or a
+            # brightness does not switch the myGekko light on, so reporting it
+            # as on would be a lie that outlives the next poll.
+            self._set_optimistic("state", LightState.ON, self._light.state)
         await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/mygekko/select.py
+++ b/custom_components/mygekko/select.py
@@ -48,15 +48,13 @@ class MyGekkoVentBypassSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.bypass_state)
-            if self._vent.bypass_state is not None
-            else None
-        )
+        bypass_state = self._get_optimistic("bypass_state", self._vent.bypass_state)
+        return str(bypass_state) if bypass_state is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_bypass_state(option)
+        self._set_optimistic("bypass_state", option, self._vent.bypass_state)
         await self.coordinator.async_request_refresh()
 
 
@@ -81,15 +79,13 @@ class MyGekkoVentWorkingModeSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.working_mode)
-            if self._vent.working_mode is not None
-            else None
-        )
+        working_mode = self._get_optimistic("working_mode", self._vent.working_mode)
+        return str(working_mode) if working_mode is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_mode(option)
+        self._set_optimistic("working_mode", option, self._vent.working_mode)
         await self.coordinator.async_request_refresh()
 
 
@@ -115,13 +111,11 @@ class MyGekkoVentWorkingLevelSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.working_level)
-            if self._vent.working_level is not None
-            else None
-        )
+        working_level = self._get_optimistic("working_level", self._vent.working_level)
+        return str(working_level) if working_level is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_level(option)
+        self._set_optimistic("working_level", option, self._vent.working_level)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/switch.py
+++ b/custom_components/mygekko/switch.py
@@ -34,17 +34,17 @@ class MyGekkoSwitch(MyGekkoEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Check wether the swich is on."""
-        return (
-            self._load.state == LoadState.ON_PERMANENT
-            or self._load.state == LoadState.ON_IMPULSE
-        )
+        state = self._get_optimistic("state", self._load.state)
+        return state == LoadState.ON_PERMANENT or state == LoadState.ON_IMPULSE
 
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
         await self._load.set_state(LoadState.OFF)
+        self._set_optimistic("state", LoadState.OFF, self._load.state)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
         await self._load.set_state(LoadState.ON_PERMANENT)
+        self._set_optimistic("state", LoadState.ON_PERMANENT, self._load.state)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/water_heater.py
+++ b/custom_components/mygekko/water_heater.py
@@ -60,29 +60,42 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
         """Turn off the water heater."""
         _LOGGER.debug("Switch off water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.OFF)
+        self._set_optimistic(
+            "state", HotWaterSystemState.OFF, self._hotwater_system.state
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the water heater."""
         _LOGGER.debug("Switch on water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.ON)
+        self._set_optimistic(
+            "state", HotWaterSystemState.ON, self._hotwater_system.state
+        )
         await self.coordinator.async_request_refresh()
 
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature of the water heater."""
+        target_temperature = self._get_optimistic(
+            "target_temperature", self._hotwater_system.target_temperature
+        )
         _LOGGER.debug(
             "The water heaters %s current target temperature is %s",
             self._hotwater_system.name,
-            self._hotwater_system.target_temperature,
+            target_temperature,
         )
 
-        return self._hotwater_system.target_temperature
+        return target_temperature
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        await self._hotwater_system.set_target_temperature(
-            float(kwargs[ATTR_TEMPERATURE])
+        target_temperature = float(kwargs[ATTR_TEMPERATURE])
+        await self._hotwater_system.set_target_temperature(target_temperature)
+        self._set_optimistic(
+            "target_temperature",
+            target_temperature,
+            self._hotwater_system.target_temperature,
         )
         await self.coordinator.async_request_refresh()
 
@@ -100,7 +113,8 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
-        if self._hotwater_system.state == HotWaterSystemState.OFF:
+        state = self._get_optimistic("state", self._hotwater_system.state)
+        if state == HotWaterSystemState.OFF:
             return STATE_OFF
         else:
             return STATE_ON


### PR DESCRIPTION
Based directly on `main`, no dependency on any other open PR.

## The problem

The myGEKKO Query API is polling-only — there is no push channel, so the integration only learns about a state change on the next coordinator refresh. After sending a command the UI therefore snaps back to the old state and stays there until that refresh lands. Toggling a light looks like it did nothing, and on a slow controller a user will click it a second time.

`async_request_refresh()` after each command (added in #339) shortens the wait, but does not remove it: the refresh often still reads the *pre-command* value, because the myGEKKO has not applied the command yet. That stale poll actively flips the state back, which is worse than just waiting.

## The change

`MyGekkoEntity` gets two helpers, `_set_optimistic(key, optimistic_value, polled_value)` and `_get_optimistic(key, polled_value)`. A command handler reports the value it just sent *plus* the value that was polled at that moment; the state properties read through `_get_optimistic`, which returns the optimistic value while it is still valid and the polled value otherwise.

The stored polled value is what makes this safe. The optimistic value is dropped as soon as the polled value **changes** — that is the signal that the myGEKKO has actually processed the command — rather than after a fixed delay. A stale poll returning the old value therefore does not flip the state back, and a poll returning the *new* value hands over to the real value immediately. There is no window in which a genuine external change (someone at the wall switch) is masked longer than necessary.

The fallback is a 60s timeout, for commands the myGEKKO silently never applies. Without it the entity would show the optimistic value forever, since the polled value never changes.

Covered platforms and keys:

| Platform | Optimistic |
|---|---|
| `switch` | state |
| `light` | state, brightness, rgb_color |
| `cover` | state (opening/closing) |
| `climate` | target_temperature, working_mode |
| `water_heater` | state, target_temperature |
| `select` | bypass_state, working_mode, working_level |

Two things deliberately left out:

- **Cover position is not optimistic.** A blind genuinely takes time to travel, so reporting the target position immediately would be a lie for the whole movement. Only the opening/closing state is set, which is what the UI needs for the arrows. `async_set_cover_position` derives the direction from the target vs. the currently polled position, and skips it when the position is unknown or unchanged.
- **Tilt is not optimistic** beyond the shared stop handler, for the same reason.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

