### PR TITLE
Fix camera entities: setup TypeError on current HA versions and digest auth for image fetching

### DIFF
--- a/custom_components/mygekko/camera.py
+++ b/custom_components/mygekko/camera.py
@@ -40,10 +40,10 @@ class MyGekkoInterComCam(MyGekkoEntity, Camera):
 
         self._door_inter_com = door_inter_com
         supported_features = self._door_inter_com.supported_features
-        self._attr_supported_features = 0
+        self._attr_supported_features = CameraEntityFeature(0)
 
-        if CamFeature.STREAM in supported_features:
-            self._attr_supported_features |= DoorInterComFeature.STREAM
+        if DoorInterComFeature.STREAM in supported_features:
+            self._attr_supported_features |= CameraEntityFeature.STREAM
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -86,7 +86,7 @@ class MyGekkoCam(MyGekkoEntity, Camera):
 
         self._cam = cam
         supported_features = self._cam.supported_features
-        self._attr_supported_features = 0
+        self._attr_supported_features = CameraEntityFeature(0)
 
         if CamFeature.STREAM in supported_features:
             self._attr_supported_features |= CameraEntityFeature.STREAM

--- a/custom_components/mygekko/camera.py
+++ b/custom_components/mygekko/camera.py
@@ -9,12 +9,65 @@ from PyMyGekko.resources.Cams import Cam
 from PyMyGekko.resources.Cams import CamFeature
 from PyMyGekko.resources.DoorInterComs import DoorInterCom
 from PyMyGekko.resources.DoorInterComs import DoorInterComFeature
+from yarl import URL
 
 from .const import DOMAIN
 from .entity import MyGekkoEntity
 
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+IMAGE_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+
+async def _async_fetch_camera_image(image_url: str, camera_name: str) -> bytes | None:
+    """Fetch a camera image, supporting basic and digest auth credentials in the URL."""
+    url = URL(image_url)
+    auth = None
+    if url.user is not None:
+        # aiohttp rejects requests that combine an auth argument with
+        # credentials embedded in the URL, so strip them from the URL.
+        auth = aiohttp.BasicAuth(url.user, url.password or "")
+        url = url.with_user(None)
+
+    try:
+        async with aiohttp.ClientSession(
+            timeout=IMAGE_TIMEOUT
+        ) as session, session.get(url, auth=auth) as resp:
+            if resp.status == 200:
+                return await resp.read()
+            www_authenticate = resp.headers.get("WWW-Authenticate", "")
+            needs_digest = (
+                resp.status == 401
+                and auth is not None
+                and www_authenticate.lower().startswith("digest")
+            )
+            if not needs_digest:
+                _LOGGER.error(
+                    "Error fetching camera image from camera %s: HTTP %s",
+                    camera_name,
+                    resp.status,
+                )
+                return None
+
+        # The camera only accepts digest auth (e.g. Axis cameras), retry with it.
+        digest_auth = aiohttp.DigestAuthMiddleware(auth.login, auth.password)
+        async with aiohttp.ClientSession(
+            timeout=IMAGE_TIMEOUT, middlewares=(digest_auth,)
+        ) as session, session.get(url) as resp:
+            if resp.status != 200:
+                _LOGGER.error(
+                    "Error fetching camera image from camera %s with digest auth: HTTP %s",
+                    camera_name,
+                    resp.status,
+                )
+                return None
+            return await resp.read()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.error(
+            "Error fetching camera image from camera %s: %s", camera_name, err
+        )
+        return None
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
@@ -59,19 +112,10 @@ class MyGekkoInterComCam(MyGekkoEntity, Camera):
     ) -> bytes | None:
         """Return bytes of camera image."""
         if self._door_inter_com.image_url:
-            try:
-                async with aiohttp.ClientSession() as session, session.get(self._door_inter_com.image_url) as resp:
-                    if resp.status != 200:
-                        _LOGGER.error("Error fetching camera image from camera %s. Error: %s", self._door_inter_com.name, resp.msg)
-                        return None
-                    image_bytes = await resp.read()
-
-                return image_bytes
-
-            except Exception:
-                return None
-        else:
-            return None
+            return await _async_fetch_camera_image(
+                self._door_inter_com.image_url, self._door_inter_com.name
+            )
+        return None
 
 
 class MyGekkoCam(MyGekkoEntity, Camera):
@@ -105,16 +149,5 @@ class MyGekkoCam(MyGekkoEntity, Camera):
     ) -> bytes | None:
         """Return bytes of camera image."""
         if self._cam.image_url:
-            try:
-                async with aiohttp.ClientSession() as session, session.get(self._cam.image_url) as resp:
-                    if resp.status != 200:
-                        _LOGGER.error("Error fetching camera image from camera %s. Error: %s", self._cam.name, resp.msg)
-                        return None
-                    image_bytes = await resp.read()
-
-                return image_bytes
-
-            except Exception:
-                return None
-        else:
-            return None
+            return await _async_fetch_camera_image(self._cam.image_url, self._cam.name)
+        return None


### PR DESCRIPTION
## Summary

Camera entities are currently completely broken on recent Home Assistant versions, and even once they load, snapshots fail for cameras that only accept HTTP digest auth (e.g. Axis cameras). This PR fixes both, found while debugging a production installation with several Axis cameras behind a myGEKKO unit.

### 1. Cameras fail to be added (`TypeError`)

`_attr_supported_features` was initialized with a plain `0`. Recent HA versions check `CameraEntityFeature.STREAM not in self.supported_features` when the entity is added, which raises:

```
TypeError: argument of type 'int' is not a container or iterable
```

Every camera without stream support died with `Error adding entity camera.* for domain camera with platform mygekko`. Fixed by initializing with `CameraEntityFeature(0)`.

The door intercom class additionally checked `CamFeature.STREAM` against `DoorInterCom.supported_features` (which contains `DoorInterComFeature` values — it only worked because both enums share the value 1) and OR-ed the PyMyGekko `DoorInterComFeature.STREAM` enum into the HA feature flags instead of `CameraEntityFeature.STREAM`. Both now use the proper enums.

### 2. Snapshots fail for digest-auth cameras

myGEKKO delivers the camera `imagepath` as `http://user:pw@<camera-ip>/...` — credentials embedded in basic auth syntax. Cameras such as Axis models only offer digest auth (`WWW-Authenticate: Digest ...`) and always answer 401 to basic auth, and the previous code swallowed every failure with a bare `except Exception: return None`, so nothing ever showed up in the logs.

The new shared `_async_fetch_camera_image` helper:
- extracts the credentials from the URL and tries basic auth first (unchanged behavior for basic-auth cameras),
- retries with aiohttp's `DigestAuthMiddleware` when the camera answers with a digest challenge,
- logs fetch failures with the HTTP status instead of silently returning `None`,
- bounds requests with a 10s timeout instead of aiohttp's 5 minute default (an unreachable camera used to hang the snapshot request).

Note: `DigestAuthMiddleware` requires aiohttp >= 3.12, shipped with HA since mid-2025.

## Testing

- Verified on a live installation (HA 2026.x, myGEKKO with 8 Axis cameras): all camera entities are added again and deliver live snapshot images.
- Basic auth, digest auth, wrong credentials, and no credentials paths exercised against a local aiohttp test server implementing an Axis-style digest challenge (MD5, qop="auth").
- `ruff check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)