### PR TITLE
Add clocks, energy manager, charging station and heating circuit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ MyGekko integration for HomeAssistant using the [PyMyGekko](https://github.com/S
 | `climate`      | Thermostats (called roomtemps in MyGekko)                          |
 | `cover`        | Covers (called blinds in MyGekko)                                  |
 | `light`        | Lights                                                             |
-| `switch`       | Switches (called loads in MyGekko)                                 |
+| `switch`       | Switches (called loads in MyGekko) and charging station start/stop (emobils) |
 | `water_heater` | Water Heater (called hotwater_systems in MyGekko)                  |
-| `sensor`       | MyGekko energy_cost metrics and alarms_logics are added as sensors |
+| `sensor`       | Metrics for energy_cost, alarms_logics, energymanager (PV/grid/battery), heatingcircuits and emobils (charging stations) |
 | `scene`        | MyGekko actions are added as scenes                                |
+| `select`       | Vent modes and clocks (schedule timers: off/on/onCoincidence)      |
+| `number`       | Charging station charge power setpoint (emobils)                   |
 
 ![Dashboard Screenshot][dashboard-screenshot]
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ custom_components/mygekko/switch.py
 
 The integration supports access via the MyGekko Query Api (you need a MyGekko Plus subscription) or by connecting to your MyGekko locally.
 
+To change the settings of an existing entry — IP address, credentials or even the connection type itself — open "Settings" -> "Devices & services" -> "MyGekko" and pick "Reconfigure" from the entry's menu.
+
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)

--- a/custom_components/mygekko/__init__.py
+++ b/custom_components/mygekko/__init__.py
@@ -9,13 +9,17 @@ from custom_components.mygekko.coordinator import MyGekkoDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core_config import Config
+from homeassistant.core import callback
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_CONNECTION_MY_GEKKO_CLOUD
 from .const import CONF_CONNECTION_TYPE
 from .const import DOMAIN
 from .const import PLATFORMS
 from .const import STARTUP_MESSAGE
+from .entity import scoped_id
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -45,24 +49,100 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry):
+async def _async_scope_registries_to_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Namespace already registered entities and devices to their config entry.
+
+    Before version 4 the unique ids and device identifiers were built from the
+    controller local resource id only, so a second controller could not be set up.
+    Prefixing the existing registry entries keeps the entities (and their history)
+    of already configured controllers intact.
+    """
+    entry_id = config_entry.entry_id
+    # A device that already clashed is linked to both config entries, so it can show
+    # up here again after the other entry migrated it. Anything carrying a known entry
+    # id is therefore already scoped and must be left alone.
+    known_prefixes = tuple(
+        f"{entry.entry_id}_" for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+
+    device_registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(device_registry, entry_id):
+        identifiers = set()
+        for domain, identifier in device.identifiers:
+            if domain == DOMAIN and not identifier.startswith(known_prefixes):
+                identifier = scoped_id(entry_id, identifier)
+            identifiers.add((domain, identifier))
+
+        if identifiers == device.identifiers:
+            continue
+
+        taken = [
+            identifier
+            for identifier in identifiers
+            if (other := device_registry.async_get_device(identifiers={identifier}))
+            and other.id != device.id
+        ]
+        if taken:
+            # async_update_device would raise and leave the migration half applied.
+            _LOGGER.warning(
+                "Skipping device migration, identifiers %s are already in use", taken
+            )
+            continue
+
+        device_registry.async_update_device(device.id, new_identifiers=identifiers)
+
+    entity_registry = er.async_get(hass)
+
+    @callback
+    def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict | None:
+        if entity_entry.unique_id.startswith(known_prefixes):
+            return None
+
+        new_unique_id = scoped_id(entry_id, entity_entry.unique_id)
+        if conflict := entity_registry.async_get_entity_id(
+            entity_entry.domain, entity_entry.platform, new_unique_id
+        ):
+            # async_update_entity would raise and leave the migration half applied.
+            _LOGGER.warning(
+                "Skipping migration of %s, unique id %s is already used by %s",
+                entity_entry.entity_id,
+                new_unique_id,
+                conflict,
+            )
+            return None
+
+        return {"new_unique_id": new_unique_id}
+
+    await er.async_migrate_entries(hass, entry_id, _migrate_unique_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version > 4:
+        # Downgrade from a future version is not supported.
+        return False
 
     if config_entry.version == 1:
         new = {**config_entry.data}
         new[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
 
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version=2)
 
     if config_entry.version == 2:
         new = {**config_entry.data}
         new[CONF_API_KEY] = new["apikey"]
         new.pop("apikey")
 
-        config_entry.version = 3
-        hass.config_entries.async_update_entry(config_entry, data=new)
+        hass.config_entries.async_update_entry(config_entry, data=new, version=3)
+
+    if config_entry.version == 3:
+        await _async_scope_registries_to_entry(hass, config_entry)
+
+        hass.config_entries.async_update_entry(config_entry, version=4)
 
     _LOGGER.debug("Migration to version %s successful", config_entry.version)
 

--- a/custom_components/mygekko/__init__.py
+++ b/custom_components/mygekko/__init__.py
@@ -41,7 +41,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
     return True
 
 
@@ -77,9 +76,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)

--- a/custom_components/mygekko/camera.py
+++ b/custom_components/mygekko/camera.py
@@ -40,10 +40,10 @@ class MyGekkoInterComCam(MyGekkoEntity, Camera):
 
         self._door_inter_com = door_inter_com
         supported_features = self._door_inter_com.supported_features
-        self._attr_supported_features = 0
+        self._attr_supported_features = CameraEntityFeature(0)
 
-        if CamFeature.STREAM in supported_features:
-            self._attr_supported_features |= DoorInterComFeature.STREAM
+        if DoorInterComFeature.STREAM in supported_features:
+            self._attr_supported_features |= CameraEntityFeature.STREAM
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -86,7 +86,7 @@ class MyGekkoCam(MyGekkoEntity, Camera):
 
         self._cam = cam
         supported_features = self._cam.supported_features
-        self._attr_supported_features = 0
+        self._attr_supported_features = CameraEntityFeature(0)
 
         if CamFeature.STREAM in supported_features:
             self._attr_supported_features |= CameraEntityFeature.STREAM

--- a/custom_components/mygekko/camera.py
+++ b/custom_components/mygekko/camera.py
@@ -9,12 +9,65 @@ from PyMyGekko.resources.Cams import Cam
 from PyMyGekko.resources.Cams import CamFeature
 from PyMyGekko.resources.DoorInterComs import DoorInterCom
 from PyMyGekko.resources.DoorInterComs import DoorInterComFeature
+from yarl import URL
 
 from .const import DOMAIN
 from .entity import MyGekkoEntity
 
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+IMAGE_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+
+async def _async_fetch_camera_image(image_url: str, camera_name: str) -> bytes | None:
+    """Fetch a camera image, supporting basic and digest auth credentials in the URL."""
+    url = URL(image_url)
+    auth = None
+    if url.user is not None:
+        # aiohttp rejects requests that combine an auth argument with
+        # credentials embedded in the URL, so strip them from the URL.
+        auth = aiohttp.BasicAuth(url.user, url.password or "")
+        url = url.with_user(None)
+
+    try:
+        async with aiohttp.ClientSession(
+            timeout=IMAGE_TIMEOUT
+        ) as session, session.get(url, auth=auth) as resp:
+            if resp.status == 200:
+                return await resp.read()
+            www_authenticate = resp.headers.get("WWW-Authenticate", "")
+            needs_digest = (
+                resp.status == 401
+                and auth is not None
+                and www_authenticate.lower().startswith("digest")
+            )
+            if not needs_digest:
+                _LOGGER.error(
+                    "Error fetching camera image from camera %s: HTTP %s",
+                    camera_name,
+                    resp.status,
+                )
+                return None
+
+        # The camera only accepts digest auth (e.g. Axis cameras), retry with it.
+        digest_auth = aiohttp.DigestAuthMiddleware(auth.login, auth.password)
+        async with aiohttp.ClientSession(
+            timeout=IMAGE_TIMEOUT, middlewares=(digest_auth,)
+        ) as session, session.get(url) as resp:
+            if resp.status != 200:
+                _LOGGER.error(
+                    "Error fetching camera image from camera %s with digest auth: HTTP %s",
+                    camera_name,
+                    resp.status,
+                )
+                return None
+            return await resp.read()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.error(
+            "Error fetching camera image from camera %s: %s", camera_name, err
+        )
+        return None
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
@@ -59,19 +112,10 @@ class MyGekkoInterComCam(MyGekkoEntity, Camera):
     ) -> bytes | None:
         """Return bytes of camera image."""
         if self._door_inter_com.image_url:
-            try:
-                async with aiohttp.ClientSession() as session, session.get(self._door_inter_com.image_url) as resp:
-                    if resp.status != 200:
-                        _LOGGER.error("Error fetching camera image from camera %s. Error: %s", self._door_inter_com.name, resp.msg)
-                        return None
-                    image_bytes = await resp.read()
-
-                return image_bytes
-
-            except Exception:
-                return None
-        else:
-            return None
+            return await _async_fetch_camera_image(
+                self._door_inter_com.image_url, self._door_inter_com.name
+            )
+        return None
 
 
 class MyGekkoCam(MyGekkoEntity, Camera):
@@ -105,16 +149,5 @@ class MyGekkoCam(MyGekkoEntity, Camera):
     ) -> bytes | None:
         """Return bytes of camera image."""
         if self._cam.image_url:
-            try:
-                async with aiohttp.ClientSession() as session, session.get(self._cam.image_url) as resp:
-                    if resp.status != 200:
-                        _LOGGER.error("Error fetching camera image from camera %s. Error: %s", self._cam.name, resp.msg)
-                        return None
-                    image_bytes = await resp.read()
-
-                return image_bytes
-
-            except Exception:
-                return None
-        else:
-            return None
+            return await _async_fetch_camera_image(self._cam.image_url, self._cam.name)
+        return None

--- a/custom_components/mygekko/climate.py
+++ b/custom_components/mygekko/climate.py
@@ -67,30 +67,36 @@ class MyGekkoRoomTempClimate(MyGekkoEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        return self._room_temp.target_temperature
+        return self._get_optimistic(
+            "target_temperature", self._room_temp.target_temperature
+        )
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
-        await self._room_temp.set_target_temperature(float(kwargs[ATTR_TEMPERATURE]))
+        target_temperature = float(kwargs[ATTR_TEMPERATURE])
+        await self._room_temp.set_target_temperature(target_temperature)
+        self._set_optimistic(
+            "target_temperature",
+            target_temperature,
+            self._room_temp.target_temperature,
+        )
         await self.coordinator.async_request_refresh()
 
     @property
     def preset_mode(self) -> str | None:
         """Return preset mode."""
-        _LOGGER.debug(
-            "The mode of %s is %s", self._room_temp.name, self._room_temp.working_mode
+        working_mode = self._get_optimistic(
+            "working_mode", self._room_temp.working_mode
         )
+        _LOGGER.debug("The mode of %s is %s", self._room_temp.name, working_mode)
 
-        return (
-            str(self._room_temp.working_mode)
-            if self._room_temp.working_mode is not None
-            else None
-        )
+        return str(working_mode) if working_mode is not None else None
 
     async def async_set_preset_mode(self, preset_mode) -> None:
         """Set new preset mode."""
 
         await self._room_temp.set_working_mode(preset_mode)
+        self._set_optimistic("working_mode", preset_mode, self._room_temp.working_mode)
         await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -60,7 +60,7 @@ LOCAL_CONNECTION_SCHEMA = vol.Schema(
 class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for mygekko."""
 
-    VERSION = 3
+    VERSION = 4
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -108,7 +108,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_selection",
-            data_schema=self._with_current_values(CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(CONNECTION_SCHEMA, user_input),
             errors=self._errors,
             last_step=False,
         )
@@ -143,7 +143,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_mygekko_cloud",
-            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA, user_input),
             errors=self._errors,
         )
 
@@ -177,7 +177,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_local",
-            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA),
+            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA, user_input),
             errors=self._errors,
         )
 
@@ -186,13 +186,18 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Return whether an existing entry is being reconfigured."""
         return self.source == config_entries.SOURCE_RECONFIGURE
 
-    def _with_current_values(self, schema):
-        """Prefill a form with the data of the entry that is being reconfigured."""
+    def _with_current_values(self, schema, user_input=None):
+        """Prefill a form with the data of the entry that is being reconfigured.
+
+        What the user just submitted takes precedence over what is stored, so a
+        form redisplayed after a validation error keeps their input instead of
+        resetting it to the values they are trying to replace.
+        """
         if not self._is_reconfigure:
             return schema
 
         return self.add_suggested_values_to_schema(
-            schema, self._get_reconfigure_entry().data
+            schema, {**self._get_reconfigure_entry().data, **(user_input or {})}
         )
 
     def _async_update_entry(self, data):
@@ -238,8 +243,10 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             globals_network = client.get_globals_network()
             if globals_network:
                 return globals_network.get("gekkoname")
-        except ClientConnectorError:
-            _LOGGER.exception("ClientConnectorError")
-        except MyGekkoError:
-            _LOGGER.exception("MyGekkoError")
+        except Exception:  # noqa: BLE001
+            # The name is only used as the entry title and has a fallback, so no
+            # failure here may abort a flow whose credentials already validated.
+            # get_globals_network() indexes the payload without guarding, which
+            # raises KeyError on an unexpected response.
+            _LOGGER.debug("Could not determine the gekko name", exc_info=True)
         return None

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -78,6 +78,13 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_connection_selection(user_input)
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle a flow initialized by reconfiguring an existing entry."""
+        self._errors = {}
+        _LOGGER.debug("Config flow async_step_reconfigure %s", user_input)
+
+        return await self.async_step_connection_selection(user_input)
+
     async def async_step_connection_selection(self, user_input):
         """Show the configuration form to edit location data."""
         _LOGGER.debug("Config flow async_step_connection_selection %s", user_input)
@@ -92,13 +99,16 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_connection_local(user_input)
 
             if connection_type == CONF_CONNECTION_DEMO_MODE:
+                if self._is_reconfigure:
+                    return self._async_update_entry(user_input)
+
                 return self.async_create_entry(
                     title=CONF_CONNECTION_DEMO_MODE_LABEL, data=user_input
                 )
 
         return self.async_show_form(
             step_id="connection_selection",
-            data_schema=CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(CONNECTION_SCHEMA),
             errors=self._errors,
             last_step=False,
         )
@@ -120,6 +130,9 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
+                    if self._is_reconfigure:
+                        return self._async_update_entry(user_input)
+
                     gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
                         title=gekko_name or user_input[CONF_GEKKOID],
@@ -130,7 +143,7 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_mygekko_cloud",
-            data_schema=CLOUD_CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(CLOUD_CONNECTION_SCHEMA),
             errors=self._errors,
         )
 
@@ -151,6 +164,9 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_LOCAL
+                    if self._is_reconfigure:
+                        return self._async_update_entry(user_input)
+
                     gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
                         title=gekko_name or user_input[CONF_IP_ADDRESS],
@@ -161,8 +177,31 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="connection_local",
-            data_schema=LOCAL_CONNECTION_SCHEMA,
+            data_schema=self._with_current_values(LOCAL_CONNECTION_SCHEMA),
             errors=self._errors,
+        )
+
+    @property
+    def _is_reconfigure(self):
+        """Return whether an existing entry is being reconfigured."""
+        return self.source == config_entries.SOURCE_RECONFIGURE
+
+    def _with_current_values(self, schema):
+        """Prefill a form with the data of the entry that is being reconfigured."""
+        if not self._is_reconfigure:
+            return schema
+
+        return self.add_suggested_values_to_schema(
+            schema, self._get_reconfigure_entry().data
+        )
+
+    def _async_update_entry(self, data):
+        """Update the entry that is being reconfigured and finish the flow."""
+        # Replace the data instead of merging it, so switching the connection
+        # type does not leave the credentials of the previous one behind. The
+        # title is left untouched, the user may have renamed the entry.
+        return self.async_update_reload_and_abort(
+            self._get_reconfigure_entry(), data=data
         )
 
     async def _test_credentials_cloud_mygekko(self, username, apikey, gekkoid):

--- a/custom_components/mygekko/config_flow.py
+++ b/custom_components/mygekko/config_flow.py
@@ -113,15 +113,17 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 and CONF_API_KEY in user_input
                 and CONF_GEKKOID in user_input
             ):
-                valid = await self._test_credentials_cloud_mygekko(
+                client = await self._test_credentials_cloud_mygekko(
                     user_input[CONF_USERNAME],
                     user_input[CONF_API_KEY],
                     user_input[CONF_GEKKOID],
                 )
-                if valid:
+                if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_MY_GEKKO_CLOUD
+                    gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
-                        title=user_input[CONF_USERNAME], data=user_input
+                        title=gekko_name or user_input[CONF_GEKKOID],
+                        data=user_input,
                     )
                 else:
                     self._errors["base"] = "auth_cloud"
@@ -142,15 +144,17 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 and CONF_USERNAME in user_input
                 and CONF_PASSWORD in user_input
             ):
-                valid = await self._test_credentials_local_mygekko(
+                client = await self._test_credentials_local_mygekko(
                     user_input[CONF_IP_ADDRESS],
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
                 )
-                if valid:
+                if client is not None:
                     user_input[CONF_CONNECTION_TYPE] = CONF_CONNECTION_LOCAL
+                    gekko_name = await self._read_gekko_name(client)
                     return self.async_create_entry(
-                        title=user_input[CONF_USERNAME], data=user_input
+                        title=gekko_name or user_input[CONF_IP_ADDRESS],
+                        data=user_input,
                     )
                 else:
                     self._errors["base"] = "auth_local"
@@ -162,28 +166,41 @@ class MyGekkoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def _test_credentials_cloud_mygekko(self, username, apikey, gekkoid):
-        """Return true if credentials is valid."""
+        """Return the client if the credentials are valid, None otherwise."""
         try:
             session = async_create_clientsession(self.hass)
             client = MyGekkoQueryApiClient(username, apikey, gekkoid, session)
             await client.try_connect()
-            return True
+            return client
         except ClientConnectorError:
             _LOGGER.exception("ClientConnectorError")
         except MyGekkoError:
             _LOGGER.exception("MyGekkoError")
-        return False
+        return None
 
     async def _test_credentials_local_mygekko(self, ip_address, username, password):
-        """Return true if credentials is valid."""
+        """Return the client if the credentials are valid, None otherwise."""
         try:
             session = async_create_clientsession(self.hass, verify_ssl=False)
             client = MyGekkoLocalApiClient(username, password, session, ip_address)
             await client.try_connect()
-            return True
+            return client
         except ClientConnectorError:
             _LOGGER.exception("ClientConnectorError")
         except MyGekkoError:
             _LOGGER.exception("MyGekkoError")
 
-        return False
+        return None
+
+    async def _read_gekko_name(self, client):
+        """Read the gekko friendly name, None if it cannot be determined."""
+        try:
+            await client.read_data()
+            globals_network = client.get_globals_network()
+            if globals_network:
+                return globals_network.get("gekkoname")
+        except ClientConnectorError:
+            _LOGGER.exception("ClientConnectorError")
+        except MyGekkoError:
+            _LOGGER.exception("MyGekkoError")
+        return None

--- a/custom_components/mygekko/const.py
+++ b/custom_components/mygekko/const.py
@@ -4,7 +4,7 @@ NAME = "MyGekko"
 MANUFACTURER = "myGEKKO | Ekon GmbH"
 DOMAIN = "mygekko"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "1.2.4"
+VERSION = "1.3.0"
 
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"
 ISSUE_URL = "https://github.com/stephanu/mygekko/issues"
@@ -21,7 +21,20 @@ WATER_HEATER = "water_heater"
 BUTTON = "button"
 SELECT = "select"
 CAMERA = "camera"
-PLATFORMS = [COVER, LIGHT, CLIMATE, SWITCH, SCENE, WATER_HEATER, SENSOR, BUTTON, SELECT, CAMERA]
+NUMBER = "number"
+PLATFORMS = [
+    COVER,
+    LIGHT,
+    CLIMATE,
+    SWITCH,
+    SCENE,
+    WATER_HEATER,
+    SENSOR,
+    BUTTON,
+    SELECT,
+    CAMERA,
+    NUMBER,
+]
 
 
 # Configuration and options

--- a/custom_components/mygekko/coordinator.py
+++ b/custom_components/mygekko/coordinator.py
@@ -38,7 +38,13 @@ class MyGekkoDataUpdateCoordinator(DataUpdateCoordinator):
         entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
 
         client = None
 

--- a/custom_components/mygekko/cover.py
+++ b/custom_components/mygekko/cover.py
@@ -98,38 +98,45 @@ class MyGekkoCover(MyGekkoEntity, CoverEntity):
     @property
     def is_closing(self) -> bool:
         """Check whether the cover is closing."""
-        return (
-            self._blind.state == BlindState.DOWN
-            or self._blind.state == BlindState.HOLD_DOWN
-        )
+        state = self._get_optimistic("state", self._blind.state)
+        return state == BlindState.DOWN or state == BlindState.HOLD_DOWN
 
     @property
     def is_opening(self) -> bool:
         """Check whether the cover is opening."""
-        return (
-            self._blind.state == BlindState.UP
-            or self._blind.state == BlindState.HOLD_UP
-        )
+        state = self._get_optimistic("state", self._blind.state)
+        return state == BlindState.UP or state == BlindState.HOLD_UP
 
     async def async_open_cover(self, **kwargs: Any):
         """Open the cover."""
         await self._blind.set_state(BlindState.HOLD_UP)
+        self._set_optimistic("state", BlindState.HOLD_UP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_close_cover(self, **kwargs: Any):
         """Close cover."""
         await self._blind.set_state(BlindState.HOLD_DOWN)
+        self._set_optimistic("state", BlindState.HOLD_DOWN, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_stop_cover(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        self._set_optimistic("state", BlindState.STOP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""
         # myGekko blinds are closed on 100 and open on 0
-        await self._blind.set_position(100.0 - float(kwargs[ATTR_POSITION]))
+        position = 100.0 - float(kwargs[ATTR_POSITION])
+        await self._blind.set_position(position)
+        if self._blind.position is not None and position != self._blind.position:
+            direction = (
+                BlindState.DOWN
+                if position > self._blind.position
+                else BlindState.UP
+            )
+            self._set_optimistic("state", direction, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_open_cover_tilt(self, **kwargs: Any):
@@ -145,6 +152,7 @@ class MyGekkoCover(MyGekkoEntity, CoverEntity):
     async def async_stop_cover_tilt(self, **kwargs: Any):
         """Stop the cover."""
         await self._blind.set_state(BlindState.STOP)
+        self._set_optimistic("state", BlindState.STOP, self._blind.state)
         await self.coordinator.async_request_refresh()
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:

--- a/custom_components/mygekko/entity.py
+++ b/custom_components/mygekko/entity.py
@@ -12,6 +12,16 @@ from .const import NAME
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def scoped_id(entry_id: str, resource_id: str) -> str:
+    """Scope a MyGekko resource id to a config entry.
+
+    The ids reported by a MyGekko controller (e.g. "lightsitem13") are only unique
+    within that controller, so they have to be namespaced to keep multiple
+    controllers from clashing in the entity and device registry.
+    """
+    return f"{entry_id}_{resource_id}"
+
+
 class MyGekkoEntity(CoordinatorEntity):
     """Base Class for MyGekko entities."""
 
@@ -23,7 +33,9 @@ class MyGekkoEntity(CoordinatorEntity):
         """Initialize a MyGekko entity."""
         super().__init__(coordinator)
 
-        device_id = f"{entity_prefix}{entity.entity_id}"
+        device_id = scoped_id(
+            coordinator.config_entry.entry_id, f"{entity_prefix}{entity.entity_id}"
+        )
         device_name = entity.name
 
         self._attr_unique_id = f"{device_id}{entity_suffix}"
@@ -48,7 +60,10 @@ class MyGekkoControllerEntity(CoordinatorEntity):
         """Initialize a MyGekko controller entity."""
         super().__init__(coordinator)
 
-        device_id = f"mygekko_controller_{globals_network['gekkoname']}"
+        device_id = scoped_id(
+            coordinator.config_entry.entry_id,
+            f"mygekko_controller_{globals_network['gekkoname']}",
+        )
         device_name = globals_network["gekkoname"]
 
         self._attr_unique_id = f"{device_id}{entity_prefix}{entity.entity_id}"

--- a/custom_components/mygekko/entity.py
+++ b/custom_components/mygekko/entity.py
@@ -1,5 +1,7 @@
 """MyGekkoEntity class."""
 import logging
+import time
+from typing import Any
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -10,6 +12,11 @@ from .const import MANUFACTURER
 from .const import NAME
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+# How long (in seconds) an optimistic value is shown before falling back to
+# the polled value. Long enough to bridge a stale poll right after a command,
+# short enough to recover from commands the myGekko never applied.
+OPTIMISTIC_VALUE_TIMEOUT = 60.0
 
 
 class MyGekkoEntity(CoordinatorEntity):
@@ -23,6 +30,8 @@ class MyGekkoEntity(CoordinatorEntity):
         """Initialize a MyGekko entity."""
         super().__init__(coordinator)
 
+        self._optimistic_values: dict[str, tuple[Any, Any, float]] = {}
+
         device_id = f"{entity_prefix}{entity.entity_id}"
         device_name = entity.name
 
@@ -35,6 +44,31 @@ class MyGekkoEntity(CoordinatorEntity):
         )
 
         _LOGGER.debug("Added MyGekko entity id='%s'", self.unique_id)
+
+    def _set_optimistic(self, key: str, optimistic_value, polled_value) -> None:
+        """Show a value immediately instead of waiting for the next poll.
+
+        The optimistic value is returned by _get_optimistic until the polled
+        value changes (the myGekko has processed the command) or the timeout
+        expires (the command got lost), so a stale poll right after a command
+        does not flip the state back.
+        """
+        self._optimistic_values[key] = (
+            optimistic_value,
+            polled_value,
+            time.monotonic() + OPTIMISTIC_VALUE_TIMEOUT,
+        )
+        self.async_write_ha_state()
+
+    def _get_optimistic(self, key: str, polled_value):
+        """Return the optimistic value for key while it is valid."""
+        if key not in self._optimistic_values:
+            return polled_value
+        optimistic_value, initial_value, valid_until = self._optimistic_values[key]
+        if polled_value != initial_value or time.monotonic() >= valid_until:
+            del self._optimistic_values[key]
+            return polled_value
+        return optimistic_value
 
 
 class MyGekkoControllerEntity(CoordinatorEntity):

--- a/custom_components/mygekko/light.py
+++ b/custom_components/mygekko/light.py
@@ -61,15 +61,15 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
     @property
     def is_on(self) -> bool | None:
         """Check whether the light is on."""
-        _LOGGER.debug(
-            "The light state of %s is %d", self._light.name, self._light.state
-        )
-        return self._light.state == LightState.ON
+        state = self._get_optimistic("state", self._light.state)
+        _LOGGER.debug("The light state of %s is %d", self._light.name, state)
+        return state == LightState.ON
 
     async def async_turn_off(self, **kwargs):
         """Turn off the light."""
         _LOGGER.debug("Switch off light %s", self._light.name)
         await self._light.set_state(LightState.OFF)
+        self._set_optimistic("state", LightState.OFF, self._light.state)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
@@ -77,22 +77,25 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
         _LOGGER.debug("Switch on light %s", self._light.name)
         if ATTR_RGB_COLOR in kwargs and kwargs[ATTR_RGB_COLOR]:
             await self._light.set_rgb_color(kwargs[ATTR_RGB_COLOR])
+            self._set_optimistic(
+                "rgb_color", kwargs[ATTR_RGB_COLOR], self._light.rgb_color
+            )
         elif ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS]:
-            await self._light.set_brightness(round(kwargs[ATTR_BRIGHTNESS] / 255 * 100))
+            brightness = round(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+            await self._light.set_brightness(brightness)
+            self._set_optimistic("brightness", brightness, self._light.brightness)
         else:
             await self._light.set_state(LightState.ON)
+        self._set_optimistic("state", LightState.ON, self._light.state)
         await self.coordinator.async_request_refresh()
 
     @property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
-        return (
-            round(255 * self._light.brightness / 100)
-            if self._light.brightness is not None
-            else None
-        )
+        brightness = self._get_optimistic("brightness", self._light.brightness)
+        return round(255 * brightness / 100) if brightness is not None else None
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value [int, int, int]."""
-        return self._light.rgb_color
+        return self._get_optimistic("rgb_color", self._light.rgb_color)

--- a/custom_components/mygekko/light.py
+++ b/custom_components/mygekko/light.py
@@ -86,7 +86,10 @@ class MyGekkoLight(MyGekkoEntity, LightEntity):
             self._set_optimistic("brightness", brightness, self._light.brightness)
         else:
             await self._light.set_state(LightState.ON)
-        self._set_optimistic("state", LightState.ON, self._light.state)
+            # Only claimed for a real state command: writing a color or a
+            # brightness does not switch the myGekko light on, so reporting it
+            # as on would be a lie that outlives the next poll.
+            self._set_optimistic("state", LightState.ON, self._light.state)
         await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/mygekko/manifest.json
+++ b/custom_components/mygekko/manifest.json
@@ -13,7 +13,7 @@
     "PyMyGekko"
   ],
   "requirements": [
-    "PyMyGekko==1.5.2"
+    "PyMyGekko==1.6.0"
   ],
-  "version": "1.2.4"
+  "version": "1.3.0"
 }

--- a/custom_components/mygekko/number.py
+++ b/custom_components/mygekko/number.py
@@ -1,0 +1,57 @@
+"""Number platform for MyGekko."""
+from homeassistant.components.number import NumberDeviceClass
+from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberMode
+from homeassistant.const import UnitOfPower
+from PyMyGekko.resources.EMobils import EMobil
+
+from .const import DOMAIN
+from .entity import MyGekkoEntity
+
+# Fallback upper bound for the charge power setpoint when the charging station does
+# not report its maximum charging power. The myGekko command range is 1..100 kW.
+DEFAULT_MAX_CHARGING_POWER = 100.0
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Set up number platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_devices(
+        MyGekkoEMobilChargingPowerNumber(coordinator, emobil)
+        for emobil in coordinator.api.get_emobils()
+    )
+
+
+class MyGekkoEMobilChargingPowerNumber(MyGekkoEntity, NumberEntity):
+    """mygekko charging station charge power setpoint class."""
+
+    _attr_translation_key = "mygekko_emobil_charging_power_setpoint"
+    _attr_device_class = NumberDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
+    _attr_mode = NumberMode.BOX
+    _attr_native_min_value = 1.0
+    _attr_native_step = 0.1
+    _attr_icon = "mdi:ev-station"
+
+    def __init__(self, coordinator, emobil: EMobil):
+        """Initialize a MyGekko charging station charge power setpoint."""
+        super().__init__(coordinator, emobil, "emobils", "charging_power_setpoint")
+        self._emobil = emobil
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum charge power the station accepts."""
+        maximum = self._emobil.maximum_charging_power
+        return maximum if maximum else DEFAULT_MAX_CHARGING_POWER
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current charge power setpoint."""
+        return self._get_optimistic("setpoint", self._emobil.charging_power_setpoint)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new charge power setpoint."""
+        await self._emobil.set_charging_power_setpoint(value)
+        self._set_optimistic("setpoint", value, self._emobil.charging_power_setpoint)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/select.py
+++ b/custom_components/mygekko/select.py
@@ -1,6 +1,8 @@
 """Select platform for MyGekko."""
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.select import SelectEntityDescription
+from PyMyGekko.resources.Clocks import Clock
+from PyMyGekko.resources.Clocks import ClockState
 from PyMyGekko.resources.Vents import Vent
 from PyMyGekko.resources.Vents import VentBypassMode
 from PyMyGekko.resources.Vents import VentWorkingLevel
@@ -25,6 +27,10 @@ async def async_setup_entry(hass, entry, async_add_devices):
     async_add_devices(
         MyGekkoVentWorkingLevelSelect(coordinator, vent)
         for vent in coordinator.api.get_vents()
+    )
+    async_add_devices(
+        MyGekkoClockSelect(coordinator, clock)
+        for clock in coordinator.api.get_clocks()
     )
 
 
@@ -118,4 +124,36 @@ class MyGekkoVentWorkingLevelSelect(MyGekkoEntity, SelectEntity):
         """Change the selected option."""
         await self._vent.set_working_level(option)
         self._set_optimistic("working_level", option, self._vent.working_level)
+        await self.coordinator.async_request_refresh()
+
+
+class MyGekkoClockSelect(MyGekkoEntity, SelectEntity):
+    """mygekko clock select class."""
+
+    _attr_name = None
+
+    def __init__(self, coordinator, clock: Clock):
+        """Initialize a MyGekko clock selection."""
+        super().__init__(coordinator, clock, "clocks")
+        self._clock = clock
+        self.entity_description = SelectEntityDescription(
+            key="mygekko_clock",
+            translation_key="mygekko_clock",
+            options=[
+                str(ClockState.OFF),
+                str(ClockState.ON),
+                str(ClockState.ON_COINCIDENCE),
+            ],
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        state = self._get_optimistic("state", self._clock.state)
+        return str(state) if state is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self._clock.set_state(option)
+        self._set_optimistic("state", option, self._clock.state)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/select.py
+++ b/custom_components/mygekko/select.py
@@ -48,15 +48,13 @@ class MyGekkoVentBypassSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.bypass_state)
-            if self._vent.bypass_state is not None
-            else None
-        )
+        bypass_state = self._get_optimistic("bypass_state", self._vent.bypass_state)
+        return str(bypass_state) if bypass_state is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_bypass_state(option)
+        self._set_optimistic("bypass_state", option, self._vent.bypass_state)
         await self.coordinator.async_request_refresh()
 
 
@@ -81,15 +79,13 @@ class MyGekkoVentWorkingModeSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.working_mode)
-            if self._vent.working_mode is not None
-            else None
-        )
+        working_mode = self._get_optimistic("working_mode", self._vent.working_mode)
+        return str(working_mode) if working_mode is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_mode(option)
+        self._set_optimistic("working_mode", option, self._vent.working_mode)
         await self.coordinator.async_request_refresh()
 
 
@@ -115,13 +111,11 @@ class MyGekkoVentWorkingLevelSelect(MyGekkoEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        return (
-            str(self._vent.working_level)
-            if self._vent.working_level is not None
-            else None
-        )
+        working_level = self._get_optimistic("working_level", self._vent.working_level)
+        return str(working_level) if working_level is not None else None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self._vent.set_working_level(option)
+        self._set_optimistic("working_level", option, self._vent.working_level)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/sensor.py
+++ b/custom_components/mygekko/sensor.py
@@ -1,4 +1,8 @@
 """Sensor platform for MyGekko."""
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
 from custom_components.mygekko.entity import MyGekkoControllerEntity
 from custom_components.mygekko.entity import MyGekkoEntity
 from homeassistant.components.sensor import SensorDeviceClass
@@ -6,8 +10,10 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
+from homeassistant.const import EntityCategory
 from homeassistant.const import LIGHT_LUX
 from homeassistant.const import PERCENTAGE
+from homeassistant.const import UnitOfElectricCurrent
 from homeassistant.const import UnitOfEnergy
 from homeassistant.const import UnitOfPower
 from homeassistant.const import UnitOfSpeed
@@ -15,7 +21,20 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.const import UnitOfVolumeFlowRate
 from PyMyGekko.resources.AlarmsLogics import AlarmsLogic
 from PyMyGekko.resources.DoorInterComs import DoorInterCom
+from PyMyGekko.resources.EMobils import EMobil
+from PyMyGekko.resources.EMobils import EMobilChargeRequestState
+from PyMyGekko.resources.EMobils import EMobilChargeState
+from PyMyGekko.resources.EMobils import EMobilPluggedState
 from PyMyGekko.resources.EnergyCosts import EnergyCost
+from PyMyGekko.resources.EnergyManagers import EnergyManager
+from PyMyGekko.resources.EnergyManagers import EnergyManagerBatteryModel
+from PyMyGekko.resources.EnergyManagers import EnergyManagerComponentState
+from PyMyGekko.resources.EnergyManagers import EnergyManagerEmsEnabled
+from PyMyGekko.resources.EnergyManagers import EnergyManagerState
+from PyMyGekko.resources.HeatingCircuits import HeatingCircuit
+from PyMyGekko.resources.HeatingCircuits import HeatingCircuitCoolingModeState
+from PyMyGekko.resources.HeatingCircuits import HeatingCircuitDeviceModel
+from PyMyGekko.resources.HeatingCircuits import HeatingCircuitState
 from PyMyGekko.resources.HotWaterSystems import HotWaterSystem
 from PyMyGekko.resources.HotWaterSystems import HotWaterSystemFeature
 from PyMyGekko.resources.RoomTemps import RoomTemp
@@ -176,6 +195,383 @@ SENSOR_UNIT_MAPPING = {
 }
 
 
+def _enum_option(value):
+    """Return the lowercase enum member name as option string, or None."""
+    return value.name.lower() if value is not None else None
+
+
+def _enum_options(enum_cls) -> list[str]:
+    """Return the lowercase enum member names to use as sensor options."""
+    return [member.name.lower() for member in enum_cls]
+
+
+@dataclass(frozen=True, kw_only=True)
+class MyGekkoValueSensorDescription(SensorEntityDescription):
+    """Describes a MyGekko value sensor backed by a resource property."""
+
+    value_fn: Callable[[Any], Any]
+
+
+ENERGY_MANAGER_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
+    MyGekkoValueSensorDescription(
+        key="grid_power",
+        translation_key="mygekko_energymanager_grid_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.grid_meter_power,
+    ),
+    MyGekkoValueSensorDescription(
+        key="power_exported_to_grid",
+        translation_key="mygekko_energymanager_power_exported_to_grid",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.power_exported_to_grid,
+    ),
+    MyGekkoValueSensorDescription(
+        key="solar_power",
+        translation_key="mygekko_energymanager_solar_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.power_from_solar_panels,
+    ),
+    MyGekkoValueSensorDescription(
+        key="battery_power",
+        translation_key="mygekko_energymanager_battery_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.power_from_battery,
+    ),
+    MyGekkoValueSensorDescription(
+        key="battery_charging_power",
+        translation_key="mygekko_energymanager_battery_charging_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.power_charging_battery,
+    ),
+    MyGekkoValueSensorDescription(
+        key="home_power_consumption",
+        translation_key="mygekko_energymanager_home_power_consumption",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.home_power_consumption,
+    ),
+    MyGekkoValueSensorDescription(
+        key="alternative_power_consumption",
+        translation_key="mygekko_energymanager_alternative_power_consumption",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        value_fn=lambda em: em.alternative_power_consumption,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_energy_imported_from_grid",
+        translation_key="mygekko_energymanager_daily_energy_imported_from_grid",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_energy_imported_from_grid,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_energy_exported_to_grid",
+        translation_key="mygekko_energymanager_daily_energy_exported_to_grid",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_energy_exported_to_grid,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_energy_from_solar_panels",
+        translation_key="mygekko_energymanager_daily_energy_from_solar_panels",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_energy_from_solar_panels,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_energy_from_battery",
+        translation_key="mygekko_energymanager_daily_energy_from_battery",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_energy_from_battery,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_energy_charging_battery",
+        translation_key="mygekko_energymanager_daily_energy_charging_battery",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_energy_charging_battery,
+    ),
+    MyGekkoValueSensorDescription(
+        key="daily_home_energy_consumption",
+        translation_key="mygekko_energymanager_daily_home_energy_consumption",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        value_fn=lambda em: em.daily_home_energy_consumption,
+    ),
+    MyGekkoValueSensorDescription(
+        key="battery_soc",
+        translation_key="mygekko_energymanager_battery_soc",
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda em: em.battery_soc,
+    ),
+    MyGekkoValueSensorDescription(
+        key="max_power_consumption_from_grid",
+        translation_key="mygekko_energymanager_max_power_consumption_from_grid",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: em.max_power_consumption_from_grid,
+    ),
+    MyGekkoValueSensorDescription(
+        key="max_power_export_to_grid",
+        translation_key="mygekko_energymanager_max_power_export_to_grid",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: em.max_power_export_to_grid,
+    ),
+    MyGekkoValueSensorDescription(
+        key="max_power_solar_panels",
+        translation_key="mygekko_energymanager_max_power_solar_panels",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: em.max_power_solar_panels,
+    ),
+    MyGekkoValueSensorDescription(
+        key="max_power_battery",
+        translation_key="mygekko_energymanager_max_power_battery",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: em.max_power_battery,
+    ),
+    MyGekkoValueSensorDescription(
+        key="grid_meter_state",
+        translation_key="mygekko_energymanager_grid_meter_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerComponentState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.grid_meter_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="solar_panel_state",
+        translation_key="mygekko_energymanager_solar_panel_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerComponentState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.solar_panel_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="battery_state",
+        translation_key="mygekko_energymanager_battery_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerComponentState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.battery_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="load_shedding_state",
+        translation_key="mygekko_energymanager_load_shedding_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.load_shedding_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="ems_state",
+        translation_key="mygekko_energymanager_ems_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.ems_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="ems_enabled",
+        translation_key="mygekko_energymanager_ems_enabled",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerEmsEnabled),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.ems_enabled),
+    ),
+    MyGekkoValueSensorDescription(
+        key="battery_model",
+        translation_key="mygekko_energymanager_battery_model",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EnergyManagerBatteryModel),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda em: _enum_option(em.battery_model),
+    ),
+)
+
+
+HEATING_CIRCUIT_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
+    MyGekkoValueSensorDescription(
+        key="flow_temperature",
+        translation_key="mygekko_heatingcircuit_flow_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda hc: hc.flow_temperature,
+    ),
+    MyGekkoValueSensorDescription(
+        key="return_flow_temperature",
+        translation_key="mygekko_heatingcircuit_return_flow_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda hc: hc.return_flow_temperature,
+    ),
+    MyGekkoValueSensorDescription(
+        key="dew_point",
+        translation_key="mygekko_heatingcircuit_dew_point",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda hc: hc.dew_point,
+    ),
+    MyGekkoValueSensorDescription(
+        key="flow_temperature_setpoint",
+        translation_key="mygekko_heatingcircuit_flow_temperature_setpoint",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda hc: hc.flow_temperature_setpoint,
+    ),
+    MyGekkoValueSensorDescription(
+        key="pump_working_level",
+        translation_key="mygekko_heatingcircuit_pump_working_level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:gauge",
+        value_fn=lambda hc: hc.pump_working_level,
+    ),
+    MyGekkoValueSensorDescription(
+        key="valve_opening_level",
+        translation_key="mygekko_heatingcircuit_valve_opening_level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        icon="mdi:valve",
+        value_fn=lambda hc: hc.valve_opening_level,
+    ),
+    MyGekkoValueSensorDescription(
+        key="cooling_mode_state",
+        translation_key="mygekko_heatingcircuit_cooling_mode_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(HeatingCircuitCoolingModeState),
+        value_fn=lambda hc: _enum_option(hc.cooling_mode_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="state",
+        translation_key="mygekko_heatingcircuit_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(HeatingCircuitState),
+        value_fn=lambda hc: _enum_option(hc.state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="device_model",
+        translation_key="mygekko_heatingcircuit_device_model",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(HeatingCircuitDeviceModel),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda hc: _enum_option(hc.device_model),
+    ),
+)
+
+
+EMOBIL_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
+    MyGekkoValueSensorDescription(
+        key="charging_power",
+        translation_key="mygekko_emobil_charging_power",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        value_fn=lambda ev: ev.current_charging_power,
+    ),
+    MyGekkoValueSensorDescription(
+        key="charging_energy",
+        translation_key="mygekko_emobil_charging_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        value_fn=lambda ev: ev.current_charging_energy,
+    ),
+    MyGekkoValueSensorDescription(
+        key="charging_current_setpoint",
+        translation_key="mygekko_emobil_charging_current_setpoint",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        value_fn=lambda ev: ev.electric_current_setpoint,
+    ),
+    MyGekkoValueSensorDescription(
+        key="maximum_charging_power",
+        translation_key="mygekko_emobil_maximum_charging_power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda ev: ev.maximum_charging_power,
+    ),
+    MyGekkoValueSensorDescription(
+        key="plugged_state",
+        translation_key="mygekko_emobil_plugged_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EMobilPluggedState),
+        value_fn=lambda ev: _enum_option(ev.plugged_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_state",
+        translation_key="mygekko_emobil_charge_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EMobilChargeState),
+        value_fn=lambda ev: _enum_option(ev.charge_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_request_state",
+        translation_key="mygekko_emobil_charge_request_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=_enum_options(EMobilChargeRequestState),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda ev: _enum_option(ev.charge_request_state),
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_duration",
+        translation_key="mygekko_emobil_charge_duration",
+        icon="mdi:timer-outline",
+        value_fn=lambda ev: ev.charge_duration_time,
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_start_time",
+        translation_key="mygekko_emobil_charge_start_time",
+        icon="mdi:clock-start",
+        value_fn=lambda ev: ev.charge_start_time,
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_user",
+        translation_key="mygekko_emobil_charge_user",
+        icon="mdi:account",
+        value_fn=lambda ev: ev.charge_user_name,
+    ),
+    MyGekkoValueSensorDescription(
+        key="charge_user_index",
+        translation_key="mygekko_emobil_charge_user_index",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda ev: ev.charge_user_index,
+    ),
+)
+
+
 async def async_setup_entry(hass, entry, async_add_devices):
     """Set up sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
@@ -276,6 +672,31 @@ async def async_setup_entry(hass, entry, async_add_devices):
                 MyGekkoDoorInterComMissedCalls(coordinator, door_inter_com),
 
             ]
+        )
+
+    energy_managers: list[EnergyManager] = coordinator.api.get_energy_managers()
+    for energy_manager in energy_managers:
+        async_add_devices(
+            MyGekkoValueSensor(
+                coordinator, energy_manager, "energy_manager", description
+            )
+            for description in ENERGY_MANAGER_SENSORS
+        )
+
+    heating_circuits: list[HeatingCircuit] = coordinator.api.get_heating_circuits()
+    for heating_circuit in heating_circuits:
+        async_add_devices(
+            MyGekkoValueSensor(
+                coordinator, heating_circuit, "heating_circuits", description
+            )
+            for description in HEATING_CIRCUIT_SENSORS
+        )
+
+    emobils: list[EMobil] = coordinator.api.get_emobils()
+    for emobil in emobils:
+        async_add_devices(
+            MyGekkoValueSensor(coordinator, emobil, "emobils", description)
+            for description in EMOBIL_SENSORS
         )
 
 
@@ -803,3 +1224,26 @@ class MyGekkoDoorInterComMissedCalls(MyGekkoEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         return self._door_inter_com.missed_calls
+
+
+class MyGekkoValueSensor(MyGekkoEntity, SensorEntity):
+    """mygekko sensor backed by a resource property via the description value_fn."""
+
+    entity_description: MyGekkoValueSensorDescription
+
+    def __init__(
+        self,
+        coordinator,
+        resource,
+        entity_prefix: str,
+        description: MyGekkoValueSensorDescription,
+    ):
+        """Initialize a MyGekko value sensor."""
+        super().__init__(coordinator, resource, entity_prefix, description.key)
+        self._resource = resource
+        self.entity_description = description
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self.entity_description.value_fn(self._resource)

--- a/custom_components/mygekko/sensor.py
+++ b/custom_components/mygekko/sensor.py
@@ -1,6 +1,9 @@
 """Sensor platform for MyGekko."""
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+import re
 from typing import Any
 
 from custom_components.mygekko.entity import MyGekkoControllerEntity
@@ -19,6 +22,7 @@ from homeassistant.const import UnitOfPower
 from homeassistant.const import UnitOfSpeed
 from homeassistant.const import UnitOfTemperature
 from homeassistant.const import UnitOfVolumeFlowRate
+from homeassistant.util import dt as dt_util
 from PyMyGekko.resources.AlarmsLogics import AlarmsLogic
 from PyMyGekko.resources.DoorInterComs import DoorInterCom
 from PyMyGekko.resources.EMobils import EMobil
@@ -490,6 +494,77 @@ HEATING_CIRCUIT_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
 )
 
 
+# myGekko pre-formats the charge start into a localized, human-readable
+# timestamp whose date order and separators depend on the controller's
+# configured language (e.g. German "23.07.2026 14:47:23", US English
+# "07/23/2026 14:47:23", ISO-like "2026-07-23 14:47:23"). We try the known
+# variants; genuinely ambiguous ones (dd/mm vs mm/dd) are resolved below.
+_CHARGE_START_FORMATS = (
+    "%d.%m.%Y %H:%M:%S",  # de and most of continental Europe
+    "%d/%m/%Y %H:%M:%S",  # it / fr / es / en-GB
+    "%m/%d/%Y %H:%M:%S",  # en-US
+    "%Y-%m-%d %H:%M:%S",  # ISO-like
+    "%d-%m-%Y %H:%M:%S",  # nl
+)
+
+
+def _emobil_charge_duration_seconds(value: str | None) -> int | None:
+    """Read the elapsed charge seconds from a myGekko duration string.
+
+    Handles both "20h 50m 51s" and "20:50:51" style values by taking the
+    numeric groups (locale independent) and reading the last four as days,
+    hours, minutes and seconds. Returns None for missing or zero durations.
+    """
+    if not value:
+        return None
+    groups = [int(part) for part in re.findall(r"\d+", value)]
+    if not groups:
+        return None
+    days, hours, minutes, seconds = ([0, 0, 0, 0] + groups)[-4:]
+    total = ((days * 24 + hours) * 60 + minutes) * 60 + seconds
+    return total or None
+
+
+def _emobil_charge_start(emobil: EMobil) -> datetime | None:
+    """Parse the myGekko charge start time into a timezone-aware datetime.
+
+    myGekko reports ``chargeStartTime`` as an already-localized timestamp whose
+    layout depends on the controller language. We try the known formats and,
+    when more than one matches (e.g. dd/mm vs mm/dd), disambiguate using the
+    elapsed ``chargeDurationTime`` as a rough anchor. Exposing the result via a
+    SensorDeviceClass.TIMESTAMP sensor lets Home Assistant render the elapsed
+    time natively while the stable value stays out of the logbook. Returns None
+    when nothing parses, so the sensor reads "unknown" instead of raising.
+    """
+    value = emobil.charge_start_time
+    if not value:
+        return None
+    value = value.strip()
+
+    candidates: list[datetime] = []
+    for fmt in _CHARGE_START_FORMATS:
+        try:
+            parsed = datetime.strptime(value, fmt)
+        except (ValueError, TypeError):
+            continue
+        if parsed not in candidates:
+            candidates.append(parsed)
+    if not candidates:
+        return None
+
+    if len(candidates) > 1:
+        duration_seconds = _emobil_charge_duration_seconds(
+            emobil.charge_duration_time
+        )
+        if duration_seconds is not None:
+            anchor = (
+                dt_util.now() - timedelta(seconds=duration_seconds)
+            ).replace(tzinfo=None)
+            candidates.sort(key=lambda candidate: abs(candidate - anchor))
+
+    return candidates[0].replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+
+
 EMOBIL_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
     MyGekkoValueSensorDescription(
         key="charging_power",
@@ -546,16 +621,11 @@ EMOBIL_SENSORS: tuple[MyGekkoValueSensorDescription, ...] = (
         value_fn=lambda ev: _enum_option(ev.charge_request_state),
     ),
     MyGekkoValueSensorDescription(
-        key="charge_duration",
-        translation_key="mygekko_emobil_charge_duration",
-        icon="mdi:timer-outline",
-        value_fn=lambda ev: ev.charge_duration_time,
-    ),
-    MyGekkoValueSensorDescription(
         key="charge_start_time",
         translation_key="mygekko_emobil_charge_start_time",
+        device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-start",
-        value_fn=lambda ev: ev.charge_start_time,
+        value_fn=_emobil_charge_start,
     ),
     MyGekkoValueSensorDescription(
         key="charge_user",
@@ -702,6 +772,11 @@ async def async_setup_entry(hass, entry, async_add_devices):
 
 class MyGekkoAlarmsLogicsSensor(MyGekkoControllerEntity, SensorEntity):
     """mygekko AlarmsLogics Sensor class."""
+
+    # AlarmsLogic values are always numeric (see PyMyGekko AlarmsLogic.value).
+    # Marking them as a measurement makes them proper numeric sensors and keeps
+    # their frequent value changes out of the logbook.
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, alarms_logic: AlarmsLogic, globals_network):
         """Initialize a MyGekko AlarmsLogics sensor."""

--- a/custom_components/mygekko/switch.py
+++ b/custom_components/mygekko/switch.py
@@ -1,6 +1,8 @@
 """Switch platform for MyGekko."""
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
+from PyMyGekko.resources.EMobils import EMobil
+from PyMyGekko.resources.EMobils import EMobilChargeState
 from PyMyGekko.resources.Loads import Load
 from PyMyGekko.resources.Loads import LoadState
 
@@ -14,6 +16,11 @@ async def async_setup_entry(hass, entry, async_add_devices):
     loads = coordinator.api.get_loads()
     if loads is not None:
         async_add_devices(MyGekkoSwitch(coordinator, load) for load in loads)
+
+    async_add_devices(
+        MyGekkoEMobilChargeSwitch(coordinator, emobil)
+        for emobil in coordinator.api.get_emobils()
+    )
 
 
 class MyGekkoSwitch(MyGekkoEntity, SwitchEntity):
@@ -47,4 +54,39 @@ class MyGekkoSwitch(MyGekkoEntity, SwitchEntity):
         """Turn on the switch."""
         await self._load.set_state(LoadState.ON_PERMANENT)
         self._set_optimistic("state", LoadState.ON_PERMANENT, self._load.state)
+        await self.coordinator.async_request_refresh()
+
+
+class MyGekkoEMobilChargeSwitch(MyGekkoEntity, SwitchEntity):
+    """mygekko charging station charge switch class."""
+
+    _attr_translation_key = "mygekko_emobil_charge"
+    _attr_icon = "mdi:ev-station"
+
+    def __init__(self, coordinator, emobil: EMobil):
+        """Initialize a MyGekko charging station charge switch."""
+        super().__init__(coordinator, emobil, "emobils", "charge")
+        self._emobil = emobil
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Check whether the charging station is charging."""
+        state = self._get_optimistic("state", self._emobil.charge_state)
+        return state == EMobilChargeState.ON
+
+    async def async_turn_off(self, **kwargs):
+        """Stop charging."""
+        await self._emobil.stop_charge()
+        self._set_optimistic("state", EMobilChargeState.OFF, self._emobil.charge_state)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs):
+        """Start charging."""
+        await self._emobil.start_charge()
+        self._set_optimistic("state", EMobilChargeState.ON, self._emobil.charge_state)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/switch.py
+++ b/custom_components/mygekko/switch.py
@@ -34,17 +34,17 @@ class MyGekkoSwitch(MyGekkoEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Check wether the swich is on."""
-        return (
-            self._load.state == LoadState.ON_PERMANENT
-            or self._load.state == LoadState.ON_IMPULSE
-        )
+        state = self._get_optimistic("state", self._load.state)
+        return state == LoadState.ON_PERMANENT or state == LoadState.ON_IMPULSE
 
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
         await self._load.set_state(LoadState.OFF)
+        self._set_optimistic("state", LoadState.OFF, self._load.state)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
         await self._load.set_state(LoadState.ON_PERMANENT)
+        self._set_optimistic("state", LoadState.ON_PERMANENT, self._load.state)
         await self.coordinator.async_request_refresh()

--- a/custom_components/mygekko/translations/de.json
+++ b/custom_components/mygekko/translations/de.json
@@ -90,6 +90,13 @@
           "2": "Pluggit Auto",
           "3": "Pluggit Woche"
         }
+      },
+      "mygekko_clock": {
+        "state": {
+          "0": "Aus",
+          "1": "Ein",
+          "2": "Ein (Koinzidenz)"
+        }
       }
     },
     "sensor": {
@@ -182,6 +189,201 @@
       },
       "mygekko_meteo_temperature": {
         "name": "Temperatur"
+      },
+      "mygekko_energymanager_grid_power": {
+        "name": "Netzleistung"
+      },
+      "mygekko_energymanager_power_exported_to_grid": {
+        "name": "Einspeiseleistung"
+      },
+      "mygekko_energymanager_solar_power": {
+        "name": "Solarleistung"
+      },
+      "mygekko_energymanager_battery_power": {
+        "name": "Batterieleistung"
+      },
+      "mygekko_energymanager_battery_charging_power": {
+        "name": "Batterieladeleistung"
+      },
+      "mygekko_energymanager_home_power_consumption": {
+        "name": "Hausverbrauch"
+      },
+      "mygekko_energymanager_alternative_power_consumption": {
+        "name": "Alternativer Verbrauch"
+      },
+      "mygekko_energymanager_daily_energy_imported_from_grid": {
+        "name": "Netzbezug heute"
+      },
+      "mygekko_energymanager_daily_energy_exported_to_grid": {
+        "name": "Einspeisung heute"
+      },
+      "mygekko_energymanager_daily_energy_from_solar_panels": {
+        "name": "Solarertrag heute"
+      },
+      "mygekko_energymanager_daily_energy_from_battery": {
+        "name": "Batterieentladung heute"
+      },
+      "mygekko_energymanager_daily_energy_charging_battery": {
+        "name": "Batterieladung heute"
+      },
+      "mygekko_energymanager_daily_home_energy_consumption": {
+        "name": "Hausverbrauch heute"
+      },
+      "mygekko_energymanager_battery_soc": {
+        "name": "Batterieladestand"
+      },
+      "mygekko_energymanager_max_power_consumption_from_grid": {
+        "name": "Maximale Netzbezugsleistung"
+      },
+      "mygekko_energymanager_max_power_export_to_grid": {
+        "name": "Maximale Einspeiseleistung"
+      },
+      "mygekko_energymanager_max_power_solar_panels": {
+        "name": "Maximale Solarleistung"
+      },
+      "mygekko_energymanager_max_power_battery": {
+        "name": "Maximale Batterieleistung"
+      },
+      "mygekko_energymanager_grid_meter_state": {
+        "name": "Netzzähler-Status",
+        "state": {
+          "not_active": "Inaktiv",
+          "active": "Aktiv"
+        }
+      },
+      "mygekko_energymanager_solar_panel_state": {
+        "name": "Solaranlagen-Status",
+        "state": {
+          "not_active": "Inaktiv",
+          "active": "Aktiv"
+        }
+      },
+      "mygekko_energymanager_battery_state": {
+        "name": "Batterie-Status",
+        "state": {
+          "not_active": "Inaktiv",
+          "active": "Aktiv"
+        }
+      },
+      "mygekko_energymanager_load_shedding_state": {
+        "name": "Lastabwurf",
+        "state": {
+          "off": "Aus",
+          "on": "Ein"
+        }
+      },
+      "mygekko_energymanager_ems_state": {
+        "name": "Energiemanagement-Status",
+        "state": {
+          "off": "Aus",
+          "on": "Ein"
+        }
+      },
+      "mygekko_energymanager_ems_enabled": {
+        "name": "Energiemanagement aktiviert",
+        "state": {
+          "disabled": "Deaktiviert",
+          "enabled": "Aktiviert"
+        }
+      },
+      "mygekko_energymanager_battery_model": {
+        "name": "Batteriemodell",
+        "state": {
+          "unavailable": "Nicht verfügbar",
+          "e3dc_s10": "E3/DC S10",
+          "byd": "BYD",
+          "varta_storage": "VARTA storage",
+          "individual": "Individuell",
+          "by_sun_spec_inverters": "SunSpec-Wechselrichter"
+        }
+      },
+      "mygekko_heatingcircuit_flow_temperature": {
+        "name": "Vorlauftemperatur"
+      },
+      "mygekko_heatingcircuit_return_flow_temperature": {
+        "name": "Rücklauftemperatur"
+      },
+      "mygekko_heatingcircuit_dew_point": {
+        "name": "Taupunkt"
+      },
+      "mygekko_heatingcircuit_flow_temperature_setpoint": {
+        "name": "Vorlauf-Solltemperatur"
+      },
+      "mygekko_heatingcircuit_pump_working_level": {
+        "name": "Pumpenleistung"
+      },
+      "mygekko_heatingcircuit_valve_opening_level": {
+        "name": "Ventilöffnung"
+      },
+      "mygekko_heatingcircuit_cooling_mode_state": {
+        "name": "Kühlmodus",
+        "state": {
+          "off": "Aus",
+          "on": "Ein"
+        }
+      },
+      "mygekko_heatingcircuit_state": {
+        "name": "Status",
+        "state": {
+          "off": "Aus",
+          "on": "Ein",
+          "auto": "Auto"
+        }
+      },
+      "mygekko_heatingcircuit_device_model": {
+        "name": "Gerätemodell",
+        "state": {
+          "individual": "Individuell",
+          "buderus": "Buderus",
+          "stiebel": "Stiebel",
+          "vaillant": "Vaillant"
+        }
+      },
+      "mygekko_emobil_charging_power": {
+        "name": "Ladeleistung"
+      },
+      "mygekko_emobil_charging_energy": {
+        "name": "Lademenge"
+      },
+      "mygekko_emobil_charging_current_setpoint": {
+        "name": "Ladestrom"
+      },
+      "mygekko_emobil_maximum_charging_power": {
+        "name": "Maximale Ladeleistung"
+      },
+      "mygekko_emobil_plugged_state": {
+        "name": "Steckerstatus",
+        "state": {
+          "not_plugged": "Nicht eingesteckt",
+          "plugged": "Eingesteckt"
+        }
+      },
+      "mygekko_emobil_charge_state": {
+        "name": "Ladestatus",
+        "state": {
+          "off": "Aus",
+          "on": "Ein",
+          "paused": "Pausiert"
+        }
+      },
+      "mygekko_emobil_charge_request_state": {
+        "name": "Ladeanforderung",
+        "state": {
+          "off": "Aus",
+          "on": "Ein"
+        }
+      },
+      "mygekko_emobil_charge_duration": {
+        "name": "Ladedauer"
+      },
+      "mygekko_emobil_charge_start_time": {
+        "name": "Ladebeginn"
+      },
+      "mygekko_emobil_charge_user": {
+        "name": "Ladebenutzer"
+      },
+      "mygekko_emobil_charge_user_index": {
+        "name": "Ladebenutzer-Index"
       }
     },
     "button": {
@@ -190,6 +392,16 @@
       },
       "mygekko_light_group_off": {
         "name": "Auschalten"
+      }
+    },
+    "switch": {
+      "mygekko_emobil_charge": {
+        "name": "Laden"
+      }
+    },
+    "number": {
+      "mygekko_emobil_charging_power_setpoint": {
+        "name": "Ladeleistungs-Sollwert"
       }
     }
   }

--- a/custom_components/mygekko/translations/de.json
+++ b/custom_components/mygekko/translations/de.json
@@ -42,7 +42,8 @@
       "auth_local": "Benutzername, Password oder IP Adresse sind falsch. Details findest du in den Protokollen."
     },
     "abort": {
-      "single_instance_allowed": "Es ist nur eine einzige Instanz zulässig."
+      "single_instance_allowed": "Es ist nur eine einzige Instanz zulässig.",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/de.json
+++ b/custom_components/mygekko/translations/de.json
@@ -373,9 +373,6 @@
           "on": "Ein"
         }
       },
-      "mygekko_emobil_charge_duration": {
-        "name": "Ladedauer"
-      },
       "mygekko_emobil_charge_start_time": {
         "name": "Ladebeginn"
       },

--- a/custom_components/mygekko/translations/en.json
+++ b/custom_components/mygekko/translations/en.json
@@ -89,6 +89,13 @@
           "2": "Pluggit Auto",
           "3": "Pluggit week"
         }
+      },
+      "mygekko_clock": {
+        "state": {
+          "0": "Off",
+          "1": "On",
+          "2": "On (coincidence)"
+        }
       }
     },
     "sensor": {
@@ -181,6 +188,201 @@
       },
       "mygekko_meteo_temperature": {
         "name": "Temperature"
+      },
+      "mygekko_energymanager_grid_power": {
+        "name": "Grid Power"
+      },
+      "mygekko_energymanager_power_exported_to_grid": {
+        "name": "Power Exported to Grid"
+      },
+      "mygekko_energymanager_solar_power": {
+        "name": "Solar Power"
+      },
+      "mygekko_energymanager_battery_power": {
+        "name": "Battery Power"
+      },
+      "mygekko_energymanager_battery_charging_power": {
+        "name": "Battery Charging Power"
+      },
+      "mygekko_energymanager_home_power_consumption": {
+        "name": "Home Power Consumption"
+      },
+      "mygekko_energymanager_alternative_power_consumption": {
+        "name": "Alternative Power Consumption"
+      },
+      "mygekko_energymanager_daily_energy_imported_from_grid": {
+        "name": "Daily Energy Imported From Grid"
+      },
+      "mygekko_energymanager_daily_energy_exported_to_grid": {
+        "name": "Daily Energy Exported To Grid"
+      },
+      "mygekko_energymanager_daily_energy_from_solar_panels": {
+        "name": "Daily Energy From Solar Panels"
+      },
+      "mygekko_energymanager_daily_energy_from_battery": {
+        "name": "Daily Energy From Battery"
+      },
+      "mygekko_energymanager_daily_energy_charging_battery": {
+        "name": "Daily Energy Charging Battery"
+      },
+      "mygekko_energymanager_daily_home_energy_consumption": {
+        "name": "Daily Home Energy Consumption"
+      },
+      "mygekko_energymanager_battery_soc": {
+        "name": "Battery State of Charge"
+      },
+      "mygekko_energymanager_max_power_consumption_from_grid": {
+        "name": "Maximum Power Consumption From Grid"
+      },
+      "mygekko_energymanager_max_power_export_to_grid": {
+        "name": "Maximum Power Export To Grid"
+      },
+      "mygekko_energymanager_max_power_solar_panels": {
+        "name": "Maximum Power Solar Panels"
+      },
+      "mygekko_energymanager_max_power_battery": {
+        "name": "Maximum Power Battery"
+      },
+      "mygekko_energymanager_grid_meter_state": {
+        "name": "Grid Meter State",
+        "state": {
+          "not_active": "Not active",
+          "active": "Active"
+        }
+      },
+      "mygekko_energymanager_solar_panel_state": {
+        "name": "Solar Panel State",
+        "state": {
+          "not_active": "Not active",
+          "active": "Active"
+        }
+      },
+      "mygekko_energymanager_battery_state": {
+        "name": "Battery State",
+        "state": {
+          "not_active": "Not active",
+          "active": "Active"
+        }
+      },
+      "mygekko_energymanager_load_shedding_state": {
+        "name": "Load Shedding State",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "mygekko_energymanager_ems_state": {
+        "name": "Energy Management System State",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "mygekko_energymanager_ems_enabled": {
+        "name": "Energy Management System Enabled",
+        "state": {
+          "disabled": "Disabled",
+          "enabled": "Enabled"
+        }
+      },
+      "mygekko_energymanager_battery_model": {
+        "name": "Battery Model",
+        "state": {
+          "unavailable": "Unavailable",
+          "e3dc_s10": "E3/DC S10",
+          "byd": "BYD",
+          "varta_storage": "VARTA storage",
+          "individual": "Individual",
+          "by_sun_spec_inverters": "SunSpec inverters"
+        }
+      },
+      "mygekko_heatingcircuit_flow_temperature": {
+        "name": "Flow Temperature"
+      },
+      "mygekko_heatingcircuit_return_flow_temperature": {
+        "name": "Return Flow Temperature"
+      },
+      "mygekko_heatingcircuit_dew_point": {
+        "name": "Dew Point"
+      },
+      "mygekko_heatingcircuit_flow_temperature_setpoint": {
+        "name": "Flow Temperature Setpoint"
+      },
+      "mygekko_heatingcircuit_pump_working_level": {
+        "name": "Pump Working Level"
+      },
+      "mygekko_heatingcircuit_valve_opening_level": {
+        "name": "Valve Opening Level"
+      },
+      "mygekko_heatingcircuit_cooling_mode_state": {
+        "name": "Cooling Mode",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "mygekko_heatingcircuit_state": {
+        "name": "State",
+        "state": {
+          "off": "Off",
+          "on": "On",
+          "auto": "Auto"
+        }
+      },
+      "mygekko_heatingcircuit_device_model": {
+        "name": "Device Model",
+        "state": {
+          "individual": "Individual",
+          "buderus": "Buderus",
+          "stiebel": "Stiebel",
+          "vaillant": "Vaillant"
+        }
+      },
+      "mygekko_emobil_charging_power": {
+        "name": "Charging Power"
+      },
+      "mygekko_emobil_charging_energy": {
+        "name": "Charging Energy"
+      },
+      "mygekko_emobil_charging_current_setpoint": {
+        "name": "Charging Current"
+      },
+      "mygekko_emobil_maximum_charging_power": {
+        "name": "Maximum Charging Power"
+      },
+      "mygekko_emobil_plugged_state": {
+        "name": "Plugged State",
+        "state": {
+          "not_plugged": "Not plugged",
+          "plugged": "Plugged"
+        }
+      },
+      "mygekko_emobil_charge_state": {
+        "name": "Charge State",
+        "state": {
+          "off": "Off",
+          "on": "On",
+          "paused": "Paused"
+        }
+      },
+      "mygekko_emobil_charge_request_state": {
+        "name": "Charge Request State",
+        "state": {
+          "off": "Off",
+          "on": "On"
+        }
+      },
+      "mygekko_emobil_charge_duration": {
+        "name": "Charge Duration"
+      },
+      "mygekko_emobil_charge_start_time": {
+        "name": "Charge Start Time"
+      },
+      "mygekko_emobil_charge_user": {
+        "name": "Charge User"
+      },
+      "mygekko_emobil_charge_user_index": {
+        "name": "Charge User Index"
       }
     },
     "button": {
@@ -189,6 +391,16 @@
       },
       "mygekko_light_group_off": {
         "name": "Switch Off"
+      }
+    },
+    "switch": {
+      "mygekko_emobil_charge": {
+        "name": "Charge"
+      }
+    },
+    "number": {
+      "mygekko_emobil_charging_power_setpoint": {
+        "name": "Charge Power Setpoint"
       }
     }
   }

--- a/custom_components/mygekko/translations/en.json
+++ b/custom_components/mygekko/translations/en.json
@@ -42,7 +42,8 @@
       "auth_local": "Username/Password/IP address is wrong. Please see the logs for details."
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
+      "reconfigure_successful": "Reconfiguration was successful"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/en.json
+++ b/custom_components/mygekko/translations/en.json
@@ -372,9 +372,6 @@
           "on": "On"
         }
       },
-      "mygekko_emobil_charge_duration": {
-        "name": "Charge Duration"
-      },
       "mygekko_emobil_charge_start_time": {
         "name": "Charge Start Time"
       },

--- a/custom_components/mygekko/translations/fr.json
+++ b/custom_components/mygekko/translations/fr.json
@@ -42,7 +42,8 @@
       "auth_local": "Nom d'utilisateur ou le mot de passe ou l'adresse IP erroné. Veuillez consulter les journaux pour plus de détails."
     },
     "abort": {
-      "single_instance_allowed": "Une seule instance est autorisée."
+      "single_instance_allowed": "Une seule instance est autorisée.",
+      "reconfigure_successful": "La reconfiguration a réussi"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/it.json
+++ b/custom_components/mygekko/translations/it.json
@@ -42,7 +42,8 @@
       "auth_local": "Nome utente/Password/Indirizzo IP errati. Per i dettagli, consultare i registri."
     },
     "abort": {
-      "single_instance_allowed": "È consentita una sola istanza."
+      "single_instance_allowed": "È consentita una sola istanza.",
+      "reconfigure_successful": "La riconfigurazione è avvenuta con successo"
     }
   },
   "entity": {

--- a/custom_components/mygekko/translations/nb.json
+++ b/custom_components/mygekko/translations/nb.json
@@ -42,7 +42,8 @@
       "auth_local": "Brukernavn/Wachtwoord/IP-adres er feil. Raadpleeg de logboeken voor meer informatie."
     },
     "abort": {
-      "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang."
+      "single_instance_allowed": "Denne integrasjonen kan kun konfigureres en gang.",
+      "reconfigure_successful": "Rekonfigurering var vellykket"
     }
   },
   "entity": {

--- a/custom_components/mygekko/water_heater.py
+++ b/custom_components/mygekko/water_heater.py
@@ -60,29 +60,42 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
         """Turn off the water heater."""
         _LOGGER.debug("Switch off water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.OFF)
+        self._set_optimistic(
+            "state", HotWaterSystemState.OFF, self._hotwater_system.state
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the water heater."""
         _LOGGER.debug("Switch on water heater %s", self._hotwater_system.name)
         await self._hotwater_system.set_state(HotWaterSystemState.ON)
+        self._set_optimistic(
+            "state", HotWaterSystemState.ON, self._hotwater_system.state
+        )
         await self.coordinator.async_request_refresh()
 
     @property
     def target_temperature(self) -> float | None:
         """Return the target temperature of the water heater."""
+        target_temperature = self._get_optimistic(
+            "target_temperature", self._hotwater_system.target_temperature
+        )
         _LOGGER.debug(
             "The water heaters %s current target temperature is %s",
             self._hotwater_system.name,
-            self._hotwater_system.target_temperature,
+            target_temperature,
         )
 
-        return self._hotwater_system.target_temperature
+        return target_temperature
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        await self._hotwater_system.set_target_temperature(
-            float(kwargs[ATTR_TEMPERATURE])
+        target_temperature = float(kwargs[ATTR_TEMPERATURE])
+        await self._hotwater_system.set_target_temperature(target_temperature)
+        self._set_optimistic(
+            "target_temperature",
+            target_temperature,
+            self._hotwater_system.target_temperature,
         )
         await self.coordinator.async_request_refresh()
 
@@ -100,7 +113,8 @@ class MyGekkoWaterHeater(MyGekkoEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation ie. eco, electric, performance, ..."""
-        if self._hotwater_system.state == HotWaterSystemState.OFF:
+        state = self._get_optimistic("state", self._hotwater_system.state)
+        if state == HotWaterSystemState.OFF:
             return STATE_OFF
         else:
             return STATE_ON

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
     "hide_default_branch": true,
     "homeassistant": "2023.8.0",
     "render_readme": true,
-    "zip_release": true
+    "zip_release": false
 }

--- a/info.md
+++ b/info.md
@@ -17,10 +17,12 @@
 | `climate`      | Thermostats (called roomtemps in MyGekko)                          |
 | `cover`        | Covers (called blinds in MyGekko)                                  |
 | `light`        | Lights                                                             |
-| `switch`       | Switches (called loads in MyGekko)                                 |
+| `switch`       | Switches (called loads in MyGekko) and charging station start/stop (emobils) |
 | `water_heater` | Water Heater (called hotwater_systems in MyGekko)                  |
-| `sensor`       | MyGekko energy_cost metrics and alarms_logics are added as sensors |
+| `sensor`       | Metrics for energy_cost, alarms_logics, energymanager (PV/grid/battery), heatingcircuits and emobils (charging stations) |
 | `scene`        | MyGekko actions are added as scenes                                |
+| `select`       | Vent modes and clocks (schedule timers: off/on/onCoincidence)      |
+| `number`       | Charging station charge power setpoint (emobils)                   |
 
 ![Dashboard Screenshot][dashboard-screenshot]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pip>=21.0,<26.1
 ruff==0.15.4
 pytest-asyncio
 pytest-homeassistant-custom-component==0.13.316
-PyMyGekko==1.5.2
+PyMyGekko==1.6.0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,6 @@
 """Test MyGekko setup process."""
 import pytest
 from custom_components.mygekko import (
-    async_reload_entry,
-)
-from custom_components.mygekko import (
     async_setup_entry,
 )
 from custom_components.mygekko import (
@@ -29,7 +26,7 @@ from .const import MOCK_CONFIG
 
 
 @pytest.mark.asyncio
-async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
+async def test_setup_and_unload_entry(hass, bypass_get_data):
     """Test entry setup and unload."""
     # Create a mock entry so we don't have to go through config flow
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
@@ -38,13 +35,6 @@ async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     # them to be. Because we have patched the MyGekkoDataUpdateCoordinator.async_get_data
     # call, no code from custom_components/mygekko/api.py actually runs.
     assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], MyGekkoDataUpdateCoordinator
-    )
-
-    # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
     assert isinstance(
         hass.data[DOMAIN][config_entry.entry_id], MyGekkoDataUpdateCoordinator

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,76 @@
+"""Test MyGekko sensor helpers."""
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import patch
+
+from custom_components.mygekko import sensor
+
+
+class _FakeEMobil:
+    """Minimal stand-in exposing the charge fields the helper reads."""
+
+    def __init__(self, start, duration=None):
+        """Store the raw MyGekko charge start and duration strings."""
+        self.charge_start_time = start
+        self.charge_duration_time = duration
+
+
+def _expected(year, month, day, hour, minute, second):
+    """Build the expected timezone-aware datetime the helper should return."""
+    return datetime(
+        year, month, day, hour, minute, second, tzinfo=sensor.dt_util.DEFAULT_TIME_ZONE
+    )
+
+
+def test_charge_start_parses_german_format():
+    """The German 'dd.mm.YYYY HH:MM:SS' layout is parsed as local time."""
+    result = sensor._emobil_charge_start(_FakeEMobil("23.07.2026 14:47:23"))
+    assert result == _expected(2026, 7, 23, 14, 47, 23)
+    assert result.tzinfo is not None
+
+
+def test_charge_start_parses_iso_and_us_layouts():
+    """ISO and unambiguous US layouts are parsed to the same instant."""
+    # 23 > 12, so only the US mm/dd reading is valid - no anchor needed.
+    assert sensor._emobil_charge_start(
+        _FakeEMobil("07/23/2026 14:47:23")
+    ) == _expected(2026, 7, 23, 14, 47, 23)
+    assert sensor._emobil_charge_start(
+        _FakeEMobil("2026-07-23 14:47:23")
+    ) == _expected(2026, 7, 23, 14, 47, 23)
+
+
+def test_charge_start_ambiguous_date_uses_duration_anchor():
+    """dd/mm vs mm/dd is resolved via the elapsed-duration anchor."""
+    # "05/07/2026" could be 5 Jul (dd/mm) or 7 May (mm/dd).
+    now = datetime(2026, 5, 7, 12, 0, 0, tzinfo=timezone.utc)
+    with patch.object(sensor.dt_util, "now", return_value=now):
+        result = sensor._emobil_charge_start(
+            _FakeEMobil("05/07/2026 10:00:00", "2h 0m 0s")
+        )
+    # now - 2h = 2026-05-07 10:00, so the 7 May reading wins.
+    assert result == _expected(2026, 5, 7, 10, 0, 0)
+
+
+def test_charge_start_none_when_missing_or_invalid():
+    """Missing or unparseable start times yield None (sensor 'unknown')."""
+    assert sensor._emobil_charge_start(_FakeEMobil(None)) is None
+    assert sensor._emobil_charge_start(_FakeEMobil("")) is None
+    # The duration field's own format must not parse as a start time.
+    assert sensor._emobil_charge_start(_FakeEMobil("20h 50m 51s")) is None
+    assert sensor._emobil_charge_start(_FakeEMobil("not a date")) is None
+
+
+def test_duration_seconds_handles_letter_and_colon_formats():
+    """Both '20h 50m 51s' and '20:50:51' style durations are read."""
+    assert sensor._emobil_charge_duration_seconds("20h 50m 51s") == 75051
+    assert sensor._emobil_charge_duration_seconds("01:23:45") == 5025
+    assert sensor._emobil_charge_duration_seconds("1d 2h 3m 4s") == 93784
+
+
+def test_duration_seconds_none_when_zero_or_empty():
+    """A zero, missing or number-less duration reads as None."""
+    assert sensor._emobil_charge_duration_seconds("0h 0m 0s") is None
+    assert sensor._emobil_charge_duration_seconds("00:00:00") is None
+    assert sensor._emobil_charge_duration_seconds("") is None
+    assert sensor._emobil_charge_duration_seconds(None) is None

--- a/tests/test_unique_id.py
+++ b/tests/test_unique_id.py
@@ -1,0 +1,133 @@
+"""Test that MyGekko entities are scoped to their config entry."""
+import pytest
+from custom_components.mygekko import async_migrate_entry
+from custom_components.mygekko.const import CONF_CONNECTION_DEMO_MODE
+from custom_components.mygekko.const import CONF_CONNECTION_TYPE
+from custom_components.mygekko.const import DOMAIN
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+DEMO_CONFIG = {CONF_CONNECTION_TYPE: CONF_CONNECTION_DEMO_MODE}
+
+
+async def _setup_demo_entry(hass, entry_id):
+    """Set up a demo mode config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=DEMO_CONFIG, entry_id=entry_id, version=4
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return config_entry
+
+
+@pytest.mark.asyncio
+async def test_two_entries_do_not_clash(hass, enable_custom_integrations):
+    """Two controllers must not produce colliding unique ids."""
+    first = await _setup_demo_entry(hass, "first_entry")
+    second = await _setup_demo_entry(hass, "second_entry")
+
+    registry = er.async_get(hass)
+    first_ids = {
+        e.unique_id for e in er.async_entries_for_config_entry(registry, first.entry_id)
+    }
+    second_ids = {
+        e.unique_id for e in er.async_entries_for_config_entry(registry, second.entry_id)
+    }
+
+    assert first_ids, "no entities registered for the first entry"
+    # Both controllers expose the same resources, so equal counts prove nothing got
+    # dropped as a duplicate.
+    assert len(first_ids) == len(second_ids)
+    assert not first_ids & second_ids
+    assert all(uid.startswith("first_entry_") for uid in first_ids)
+    assert all(uid.startswith("second_entry_") for uid in second_ids)
+
+    # The devices of both controllers must stay separate too.
+    device_registry = dr.async_get(hass)
+    first_devices = dr.async_entries_for_config_entry(device_registry, first.entry_id)
+    second_devices = dr.async_entries_for_config_entry(device_registry, second.entry_id)
+    assert first_devices
+    assert not {d.id for d in first_devices} & {d.id for d in second_devices}
+
+
+@pytest.mark.asyncio
+async def test_migrate_v3_keeps_existing_entities(hass):
+    """Migrating from version 3 renames entities instead of orphaning them."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=DEMO_CONFIG, entry_id="legacy_entry", version=3
+    )
+    config_entry.add_to_hass(hass)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "lightsitem13")},
+    )
+    registry = er.async_get(hass)
+    entity = registry.async_get_or_create(
+        "light",
+        DOMAIN,
+        "lightsitem13",
+        config_entry=config_entry,
+        device_id=device.id,
+    )
+
+    assert await async_migrate_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 4
+    # Same registry rows, new ids - so entity_id and history survive.
+    assert registry.async_get(entity.entity_id).unique_id == "legacy_entry_lightsitem13"
+    assert device_registry.async_get(device.id).identifiers == {
+        (DOMAIN, "legacy_entry_lightsitem13")
+    }
+
+
+@pytest.mark.asyncio
+async def test_migration_skips_taken_unique_id(hass):
+    """A clashing target id must not abort a half applied migration."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=DEMO_CONFIG, entry_id="legacy_entry", version=3
+    )
+    config_entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    blocked = registry.async_get_or_create(
+        "light", DOMAIN, "lightsitem13", config_entry=config_entry
+    )
+    # A leftover row already occupies the id the migration wants to use.
+    registry.async_get_or_create(
+        "light", DOMAIN, "legacy_entry_lightsitem13", config_entry=config_entry
+    )
+    migratable = registry.async_get_or_create(
+        "light", DOMAIN, "lightsitem14", config_entry=config_entry
+    )
+
+    assert await async_migrate_entry(hass, config_entry)
+
+    assert config_entry.version == 4
+    # The clash is skipped, everything else still migrates.
+    assert registry.async_get(blocked.entity_id).unique_id == "lightsitem13"
+    assert (
+        registry.async_get(migratable.entity_id).unique_id == "legacy_entry_lightsitem14"
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(hass):
+    """An already scoped entry must not be prefixed twice."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=DEMO_CONFIG, entry_id="legacy_entry", version=3
+    )
+    config_entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    entity = registry.async_get_or_create(
+        "light", DOMAIN, "legacy_entry_lightsitem13", config_entry=config_entry
+    )
+
+    assert await async_migrate_entry(hass, config_entry)
+
+    assert registry.async_get(entity.entity_id).unique_id == "legacy_entry_lightsitem13"


### PR DESCRIPTION
> [!WARNING]
> **Do not merge before its prerequisites are merged — merge order matters.**
> This PR is stacked on top of fork-only changes that are not yet upstream, and it depends on a PyMyGekko release:
>
> 1. **PyMyGekko 1.6.0 first** — merge StephanU/PyMyGekko#23 and publish `1.6.0` to PyPI. Until then, CI (`pip install -r requirements.txt` → `PyMyGekko==1.6.0`) fails and the integration cannot load at runtime.
> 2. **Foundational integration changes first** — the multi-instance unique-id scoping, optimistic state updates, reconfigure flow and camera/digest-auth fixes. This branch currently **includes** those commits because the new entities build on them (e.g. the clock `select` and the charging-station `switch`/`number` use `_get_optimistic` / `_set_optimistic`, which do not exist upstream yet). Once that foundation lands upstream separately, this branch should be **rebased so only the resource commit remains**.

## Summary

Adds Home Assistant support for four myGEKKO resource types, backed by the new PyMyGekko 1.6.0 accessors:

| Resource | Platform(s) |
| --- | --- |
| `clocks` | **select** (off / on / onCoincidence) |
| `energymanager` | **sensor** — 7 power, 6 daily-energy, battery SoC, + diagnostics (component/EMS states, battery model, max power) |
| `heatingcircuits` | **sensor** — flow/return/dew-point temps, pump & valve %, cooling mode, state, device model |
| `emobils` (charging stations) | **sensor** (plugged/charge/request state, power, energy, current, user, duration …), **switch** (start/stop charging), **number** (charge power setpoint) |

- New **`number`** platform registered in `PLATFORMS`; en + de translations added.
- New sensors use a `description + value_fn` pattern (`MyGekkoValueSensor`).
- Requires **`PyMyGekko==1.6.0`**; integration bumped to **1.3.0**.

## Testing

Verified against real hardware (7 myGEKKO controllers — incl. ~20 charging stations, two energy managers, heating circuits, and the clock "Tor Hofeinfahrt"). All entities are created and report live values.

## Open point

The energymanager daily-energy sensors use **Wh** (per the API format string). If the controller actually reports these in **kWh**, switch `UnitOfEnergy.WATT_HOUR` → `KILO_WATT_HOUR` in `sensor.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
